### PR TITLE
Use forceUpdateGeneration for force-update job

### DIFF
--- a/pkg/apis/gitjob.cattle.io/v1/types.go
+++ b/pkg/apis/gitjob.cattle.io/v1/types.go
@@ -48,7 +48,7 @@ type GitJobSpec struct {
 	SyncInterval int `json:"syncInterval,omitempty"`
 
 	// ForceUpdate is a timestamp where can be set to do a force re-sync. If it is after the last synced timestamp and before the current timestamp it will be re-synced
-	ForceUpdate *metav1.Time `json:"forceUpdate,omitempty"`
+	ForceUpdateGeneration int64 `json:"forceUpdateGeneration,omitempty"`
 }
 
 type GitInfo struct {
@@ -94,6 +94,9 @@ type GitJobStatus struct {
 
 	// Generation of status to indicate if resource is out-of-sync
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// Update generation is the force update generation if spec.forceUpdateGeneration is set
+	UpdateGeneration int64 `json:"updateGeneration,omitempty"`
 
 	// Condition of the resource
 	Conditions []genericcondition.GenericCondition `json:"conditions,omitempty"`

--- a/pkg/apis/gitjob.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/gitjob.cattle.io/v1/zz_generated_deepcopy.go
@@ -147,10 +147,6 @@ func (in *GitJobSpec) DeepCopyInto(out *GitJobSpec) {
 	*out = *in
 	in.Git.DeepCopyInto(&out.Git)
 	in.JobSpec.DeepCopyInto(&out.JobSpec)
-	if in.ForceUpdate != nil {
-		in, out := &in.ForceUpdate, &out.ForceUpdate
-		*out = (*in).DeepCopy()
-	}
 	return
 }
 


### PR DESCRIPTION
Use field(int64) forceUpdateGeneration to replace forceUpdate timestamp
to control when it should re-run the job.