### PR TITLE
Add HTTP proxy support

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -24,3 +24,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+{{- if .Values.proxy }}
+            - name: HTTP_PROXY
+              value: {{ .Values.proxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.proxy }}
+            - name: NO_PROXY
+              value: {{ .Values.noProxy }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,4 +14,4 @@ global:
 # proxy: http://<username>@<password>:<url>:<port>
 
 # comma separated list of domains or ip addresses that will not use the proxy
-noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,3 +9,9 @@ tekton:
 global:
   cattle:
     systemDefaultRegistry: ""
+
+# http[s] proxy server
+# proxy: http://<username>@<password>:<url>:<port>
+
+# comma separated list of domains or ip addresses that will not use the proxy
+noProxy: 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16


### PR DESCRIPTION
This PR adds HTTP proxy support to `gitjob` and `tekton-utils` containers, by honoring standard HTTP proxy environment variables: `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`.
This should help gitjob and [fleet](https://github.com/rancher/fleet), deployed in environments behind corporate proxy, to work with external git repositories.