### PR TITLE
Bump tekton-utils to v0.1.3

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,7 +4,7 @@ gitjob:
 
 tekton:
   repository: rancher/tekton-utils
-  tag: v0.1.2
+  tag: v0.1.3
 
 global:
   cattle:


### PR DESCRIPTION
https://github.com/rancher/fleet/issues/573

```sh
% docker pull rancher/tekton-utils:v0.1.3
v0.1.3: Pulling from rancher/tekton-utils
a0d0a0d46f8b: Pull complete 
2c0a6cdfa42e: Pull complete 
e86ed7caebcd: Pull complete 
Digest: sha256:23b6b7646845b27088250cdf119a4f269aef4bf173ffd553322fe5f4f18c455f
Status: Downloaded newer image for rancher/tekton-utils:v0.1.3
docker.io/rancher/tekton-utils:v0.1.3
```