### PR TITLE
Add ability to update gitjob with branch in webhook payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gogits/go-gogs-client v0.0.0-20210131175652-1d7215cd8d85
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/mux v1.7.3
@@ -19,6 +20,7 @@ require (
 	github.com/urfave/cli v1.22.4
 	github.com/whilp/git-urls v0.0.0-20191001220047-6db9661140c0
 	gopkg.in/go-playground/webhooks.v5 v5.17.0
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.20.2
 	k8s.io/apiextensions-apiserver v0.20.2
 	k8s.io/apimachinery v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
@@ -865,6 +867,7 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/apis/gitjob.cattle.io/v1/types.go
+++ b/pkg/apis/gitjob.cattle.io/v1/types.go
@@ -69,6 +69,9 @@ type GitInfo struct {
 
 	// Git branch to watch. Default to master
 	Branch string `json:"branch,omitempty" column:"name=BRANCH,type=string,jsonpath=.spec.git.branch"`
+
+	// Semver matching for incoming tag event
+	OnTag string `json:"onTag,omitempty"`
 }
 
 type Credential struct {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,33 @@
+package webhook
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestGetBranchTagFromRef(t *testing.T) {
+	inputs := []string{
+		"refs/heads/master",
+		"refs/heads/test",
+		"refs/head/foo",
+		"refs/tags/v0.1.1",
+		"refs/tags/v0.1.2",
+		"refs/tag/v0.1.3",
+	}
+
+	outputs := [][]string{
+		{"master", ""},
+		{"test", ""},
+		{"", ""},
+		{"", "v0.1.1"},
+		{"", "v0.1.2"},
+		{"", ""},
+	}
+
+	for i, input := range inputs {
+		branch, tag := getBranchTagFromRef(input)
+		assert.Equal(t, branch, outputs[i][0])
+		assert.Equal(t, tag, outputs[i][1])
+	}
+}


### PR DESCRIPTION
Today in gitjob's webhook design, it takes incoming webhook payload and
find the gitjob that matches the repo url regarding of which branch the
commit is coming from. This will cause a problem where a single webhook
event will trigger update on every branch of gitjob. This commit adds
the ability to read branch/tag from payload and only update gitjob that
matches branch in the payload. It also adds the ability to read from tag
so that tag event is separated from push event.

https://github.com/rancher/fleet/issues/588
SURE-3590 