### PR TITLE
Add git package to image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/bci-base:15.3.17.17.8
 RUN zypper -n update && \
-    zypper -n install openssh && \
+    zypper -n install git openssh && \
     zypper -n clean -a
 RUN useradd -u 1000 -U -m gitjob
 COPY bin/gitjob /usr/bin/


### PR DESCRIPTION
Add missing `git` package to image after migration to SLE-BCI from https://github.com/rancher/gitjob/pull/50.