### PR TITLE
Revert image user to be numeric, but keep 'useradd' cmd

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,5 +4,5 @@ RUN zypper -n update && \
     zypper -n clean -a
 RUN useradd -u 1000 -U -m gitjob
 COPY bin/gitjob /usr/bin/
-USER gitjob
+USER 1000
 CMD ["gitjob"]


### PR DESCRIPTION
Revert image user to be numeric, but keep `useradd` command. It's a best practice to create the user, but we run it with the numeric user instead.

Fixes https://github.com/rancher/rancher/issues/38248