### PR TITLE
Add initial test for gitjob example

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,0 +1,107 @@
+name: E2E Gitjob
+
+on:
+  schedule:
+    # Run everyday day at 7:00 AM
+    - cron: '0 7 * * *'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'scripts/**'
+      - '*.md'
+
+env:
+  GOARCH: amd64
+  CGO_ENABLED: 0
+  SETUP_GO_VERSION: '^1.18'
+
+jobs:
+  e2e-gitjob-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k3s_version:
+          # k3d version list k3s | sed 's/+/-/' | sort -h
+          # - v1.24.1-k3s1
+          - v1.22.10-k3s1
+    steps:
+      -
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+      -
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      -
+        name: Install Ginkgo CLI
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.1
+      -
+        name: Build Binaries
+        run: |
+          go build -o "bin/gitjob"
+      -
+        name: Build Docker Images
+        run: |
+          docker build -f package/Dockerfile -t rancher/gitjob:dev .
+      -
+        name: Provision k3d Cluster
+        uses: AbsaOSS/k3d-action@v2
+        # k3d will automatically create a network named k3d-test-cluster-1 with the range 172.18.0.0/16
+        with:
+          cluster-name: "k3s-default"
+          args: >-
+            --agents 3
+            --network "nw01"
+            --image docker.io/rancher/k3s:${{matrix.k3s_version}}
+      -
+        name: Import Images Into k3d
+        run: |
+          k3d image import rancher/gitjob:dev
+      -
+        name: Deploy
+        run: |
+          # FIXME this generates a template file, can't copy it into crd/
+          go run pkg/crdgen/main.go > chart/templates/crds.yaml
+          HELM_VERSION=v0.0.0
+          sed -i \
+              -e "s/version:.*/version: $HELM_VERSION/" \
+              -e "s/appVersion:.*/appVersion: $HELM_VERSION/" \
+              chart/Chart.yaml
+          helm upgrade --install gitjob chart/ \
+            --set gitjob.tag=dev \
+            -n cattle-fleet-system --create-namespace --wait
+      -
+        name: Tests
+        run: |
+          go test -cover -tags=test $(go list ./... | grep -v /e2e)
+          ginkgo e2e/
+      -
+        name: Dump Failed Environment
+        if: failure()
+        run: |
+          mkdir -p tmp
+          kubectl get -A pod,secret,service,ingress -o json > tmp/cluster.json
+          kubectl get -A gitjobs -o json > tmp/gitjob.json
+          kubectl get -A events > tmp/events.log
+          helm list -A > tmp/helm.log
+          kubectl logs -n cattle-fleet-system -l app=gitjob > tmp/gitjobcontroller.log
+      -
+        name: Upload Logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: gha-gitjob-e2e-logs-${{ github.sha }}-${{ matrix.k3s_version }}-${{ github.run_id }}
+          path: |
+            tmp/*.json
+            tmp/*.log
+          retention-days: 2

--- a/e2e/assets/gitjob.yaml
+++ b/e2e/assets/gitjob.yaml
@@ -1,0 +1,25 @@
+apiVersion: gitjob.cattle.io/v1
+kind: GitJob
+metadata:
+  name: example
+spec:
+  git:
+    branch: master
+    repo: https://github.com/fleetrepoci/gitjobs-example
+  jobSpec:
+    template:
+      spec:
+        serviceAccountName: kubectl-apply
+        restartPolicy: "Never"
+        containers:
+        - image: "rancher/kubectl:v1.23.3"
+          name: kubectl-apply
+          command:
+          - kubectl
+          args:
+          - apply
+          - -f
+          - deployment.yaml
+          workingDir: /workspace/source
+
+

--- a/e2e/assets/rbac.yaml
+++ b/e2e/assets/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-apply
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubectl-apply
+rules:
+  - apiGroups:
+    - "apps"
+    resources:
+    - 'deployments'
+    verbs:
+    - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubectl-apply
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubectl-apply
+subjects:
+  - kind: ServiceAccount
+    name: kubectl-apply

--- a/e2e/examples_test.go
+++ b/e2e/examples_test.go
@@ -1,0 +1,48 @@
+package e2e_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rancher/gitjob/e2e/testenv"
+	"github.com/rancher/gitjob/e2e/testenv/kubectl"
+)
+
+var _ = Describe("Gitjob Examples", func() {
+	var (
+		asset string
+		k     kubectl.Command
+	)
+
+	BeforeEach(func() {
+		k = env.Kubectl
+	})
+
+	JustBeforeEach(func() {
+		out, err := k.Apply("-f", testenv.AssetPath(asset))
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+
+	AfterEach(func() {
+		out, err := k.Delete("-f", testenv.AssetPath(asset))
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		out, err = k.Delete("deployment", "nginx-deployment")
+		Expect(err).ToNot(HaveOccurred(), out)
+	})
+
+	When("creating a gitjob resource", func() {
+		Context("referencing a github repo with a deployment", func() {
+			BeforeEach(func() {
+				asset = "gitjob.yaml"
+			})
+
+			It("creates the deployment", func() {
+				Eventually(func() string {
+					out, _ := k.Get("pods")
+					return out
+				}, testenv.Timeout).Should(ContainSubstring("nginx-"))
+			})
+		})
+	})
+})

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -1,0 +1,27 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/rancher/gitjob/e2e/testenv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite for Git Repo Tests")
+}
+
+var (
+	env *testenv.Env
+)
+
+var _ = BeforeSuite(func() {
+	testenv.SetRoot("..")
+
+	env = testenv.New()
+
+	env.Kubectl.Apply("-f", testenv.AssetPath("rbac.yaml"))
+})

--- a/e2e/testenv/env.go
+++ b/e2e/testenv/env.go
@@ -1,0 +1,20 @@
+// Package testenv contains common helpers for tests
+package testenv
+
+import (
+	"time"
+
+	"github.com/rancher/gitjob/e2e/testenv/kubectl"
+)
+
+const Timeout = 5 * time.Minute
+
+type Env struct {
+	Kubectl kubectl.Command
+}
+
+func New() *Env {
+	return &Env{
+		Kubectl: kubectl.New("", "default"),
+	}
+}

--- a/e2e/testenv/kubectl/kubectl.go
+++ b/e2e/testenv/kubectl/kubectl.go
@@ -1,0 +1,78 @@
+// Package kubectl is a wrapper around the kubectl CLI
+package kubectl
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+)
+
+type Command struct {
+	cnt    string
+	ns     string
+	dir    string
+	stdout bool
+}
+
+func New(cnt string, ns string) Command {
+	return Command{cnt: cnt, ns: ns}
+}
+
+func (c Command) Namespace(ns string) Command {
+	n := c
+	n.ns = ns
+	return n
+}
+
+func (c Command) Stdout(enable bool) Command {
+	n := c
+	n.stdout = enable
+	return n
+}
+
+func (c Command) Workdir(dir string) Command {
+	n := c
+	n.dir = dir
+	return n
+}
+
+func (c Command) Apply(args ...string) (string, error) {
+	return c.Run(append([]string{"apply"}, args...)...)
+}
+
+func (c Command) Get(args ...string) (string, error) {
+	return c.Run(append([]string{"get"}, args...)...)
+}
+
+func (c Command) Delete(args ...string) (string, error) {
+	return c.Run(append([]string{"delete"}, args...)...)
+}
+
+func (c Command) Run(args ...string) (string, error) {
+	if c.ns != "" {
+		args = append([]string{"-n", c.ns}, args...)
+	}
+
+	return c.exec("kubectl", args...)
+}
+
+func (c Command) exec(command string, args ...string) (string, error) {
+	cmd := exec.Command(command, args...)
+
+	var b bytes.Buffer
+	if c.stdout {
+		cmd.Stdout = io.MultiWriter(os.Stdout, &b)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &b)
+	} else {
+		cmd.Stdout = &b
+		cmd.Stderr = &b
+	}
+
+	if c.dir != "" {
+		cmd.Dir = c.dir
+	}
+
+	err := cmd.Run()
+	return b.String(), err
+}

--- a/e2e/testenv/path.go
+++ b/e2e/testenv/path.go
@@ -1,0 +1,24 @@
+package testenv
+
+import "path"
+
+var (
+	root = "../.."
+)
+
+// SetRoot set the root path for the other relative paths, e.g. AssetPath.
+// Usually set to point to the repositories root.
+func SetRoot(dir string) {
+	root = dir
+}
+
+// Root returns the relative path to the repositories root
+func Root() string {
+	return root
+}
+
+// AssetPath returns the path to an asset
+func AssetPath(p ...string) string {
+	parts := append([]string{root, "e2e", "assets"}, p...)
+	return path.Join(parts...)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gogits/go-gogs-client v0.0.0-20210131175652-1d7215cd8d85
 	github.com/gorilla/mux v1.8.0
+	github.com/onsi/ginkgo/v2 v2.1.4
+	github.com/onsi/gomega v1.19.0
 	github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08
 	github.com/rancher/steve v0.0.0-20220628235427-dbf9ef88ce8f
 	github.com/rancher/wrangler v1.0.0
@@ -85,7 +87,7 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
-	golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717 // indirect
+	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 // indirect

--- a/go.sum
+++ b/go.sum
@@ -526,6 +526,8 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -535,7 +537,8 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
+github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
+github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -1074,8 +1077,9 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717 h1:hI3jKY4Hpf63ns040onEbB3dAkR/H/P83hw1TG8dD3Y=
 golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
+golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/scripts/test
+++ b/scripts/test
@@ -4,4 +4,4 @@ set -e
 cd $(dirname $0)/..
 
 echo Running tests
-go test -cover -tags=test ./...
+go test -cover -tags=test $(go list ./... | grep -v /e2e)


### PR DESCRIPTION
Refers to #67 by implementing the simplest example and making sure it succeeds.


Similar tests exist in fleet. 

Maybe?
- [ ] add tests for the other examples (they require much more setup)
- [ ] port tests from fleet here (might be faster, but would reduce coverage of fleet's setup)
- [ ] add test for ssh (seems necessary to catch that early)
- [ ] fix helm package script while at it (helm chart release is unusable without deleting the crd folder)
- [ ] behavior might be better tested by integration tests (external git repo control and setup is too much infrastructure) 
  - [ ] crd spec fields (by commit)
  - [ ] triggers, enqueues, ..