### PR TITLE
Roll back bci base image to 15.4.27.11.14

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.11.28
+FROM registry.suse.com/bci/bci-base:15.4.27.11.14
 RUN zypper -n update && \
     zypper -n install git openssh && \
     zypper -n clean -a


### PR DESCRIPTION
Dependentbot updated the bci base image which is pulling the wrong platform image on the s390x server. Seems like the new version has wrong platform tags. 

Rolling back to previous image tag for now.