### PR TITLE
gitjob: allow to run longer before killing leader during debugging

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
             - name: NO_PROXY
               value: {{ .Values.noProxy }}
           {{- end }}
+          {{- if .Values.debug }}
+            - name: CATTLE_DEV_MODE
+              value: "true"
+          {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
copied from fleet: gitjob: allow to run longer before killing leader during debugging

Refers to: https://github.com/rancher/fleet/pull/1212