### PR TITLE
Git validation for URLs was too strict

### DIFF
--- a/pkg/git/lsremote.go
+++ b/pkg/git/lsremote.go
@@ -70,8 +70,10 @@ func (g *git) lsRemote(branch string, commit string) (string, error) {
 	if err := validateBranch(branch); err != nil {
 		return "", err
 	}
-	if err := validateCommit(commit); err != nil {
-		return "", err
+	if commit != "" {
+		if err := validateCommit(commit); err != nil {
+			return "", err
+		}
 	}
 
 	if changed, err := g.remoteSHAChanged(branch, commit); err != nil || !changed {

--- a/pkg/git/validate.go
+++ b/pkg/git/validate.go
@@ -3,7 +3,6 @@ package git
 import (
 	"encoding/hex"
 	"fmt"
-	"net/url"
 	"strings"
 	"unicode"
 )
@@ -76,10 +75,6 @@ func validateBranch(name string) error {
 
 // validateCommit validates a commit and returns an error in case it is invalid.
 func validateCommit(commit string) error {
-	if commit == "" {
-		return nil
-	}
-
 	switch len(commit) {
 	// git supports SHA1 and SHA256 (experimental).
 	case 40, 64:
@@ -99,14 +94,6 @@ func validateURL(u string) error {
 	case len(u) > urlMaxLength:
 		return fmt.Errorf("invalid url: exceeds max length %d", urlMaxLength)
 	default:
-		u, err := url.Parse(u)
-		if err != nil {
-			return fmt.Errorf("invalid url: %w", err)
-		}
-		if u.Host == "" {
-			return fmt.Errorf("invalid url: empty host not supported: %s", u)
-		}
-
 		return nil
 	}
 }


### PR DESCRIPTION
Git URLs (see man git-url) can be in "scp-like" syntax and net/url cannot parse that.