### PR TITLE
Enable E2E for local PRs

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -87,8 +87,8 @@ jobs:
           go test -cover -tags=test $(go list ./... | grep -v /e2e)
       -
         name: E2E Tests
-        # git repo tests can't run for PRs, because PRs don't have access to the secrets
-        if: github.event_name != 'pull_request'
+        # git repo tests can't run for PRs from forks, because PRs don't have access to the secrets
+        if: github.repository == 'rancher/gitjob'
         run: |
           export GIT_SSH_KEY="$GITHUB_WORKSPACE/id_ecdsa"
           echo "${{ secrets.CI_SSH_KEY }}" > "$GIT_SSH_KEY"


### PR DESCRIPTION
[Previous attempt](https://github.com/rancher/gitjob/pull/165) to enable tests maybe failed because of problems with new validation code?

