### PR TITLE
Don't run private tests for dependabot

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -88,7 +88,7 @@ jobs:
       -
         name: E2E Tests
         # git repo tests can't run for PRs from forks, because PRs don't have access to the secrets
-        if: github.repository == 'rancher/gitjob'
+        if: github.repository == 'rancher/gitjob' && github.actor != 'dependabot[bot]'
         run: |
           export GIT_SSH_KEY="$GITHUB_WORKSPACE/id_ecdsa"
           echo "${{ secrets.CI_SSH_KEY }}" > "$GIT_SSH_KEY"


### PR DESCRIPTION
Dependabot uses its own secrets: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-encrypted-secrets-for-dependabot

Skip the tests for dependabot.