### PR TITLE
add catatonit init process

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -15,8 +15,7 @@ spec:
       containers:
         - image: "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag }}"
           name: gitjob
-          command:
-          - gitjob
+          args:
           {{- if .Values.debug }}
           - --debug
           {{- end }}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,8 @@
 FROM registry.suse.com/bci/bci-base:15.4.27.14.38
 RUN zypper -n update && \
-    zypper -n install git openssh && \
+    zypper -n install git openssh catatonit && \
     zypper -n clean -a
 RUN useradd -u 1000 -U -m gitjob
 COPY bin/gitjob /usr/bin/
 USER 1000
-CMD ["gitjob"]
+ENTRYPOINT ["catatonit", "--", "gitjob"]


### PR DESCRIPTION
`gitjob` was running with PID 1, that was creating some defunct processes. 
Using [catatonit](https://github.com/openSUSE/catatonit) as init process with PID 1 fixes the issue.

relates to https://github.com/rancher/fleet/issues/1305

supersedes https://github.com/rancher/gitjob/pull/200