### PR TITLE
Workaround updatecli templating issue

### DIFF
--- a/updatecli/scripts/update_deployment.sh
+++ b/updatecli/scripts/update_deployment.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+# Testing that we can run curl command from the GitHub Runner
+curl --help > /dev/null
+
+VERSION="$1"
+if [ -z "$VERSION" ]
+then
+    echo "Empty version provided"
+    exit 0
+fi
+
+CURRENT_VERSION="$(sed -n 's/.*.Values.tekton.tag | default "v\([.0-9]*\).*"/\1/p' ./chart/templates/deployment.yaml)"
+
+if [ "$VERSION" -eq "$CURRENT_VERSION" ]
+then
+    echo "The Tekton chart in Gitjob is already up to date."
+    exit 0
+fi
+
+
+if test "$DRY_RUN" == "true"
+then
+    echo "**DRY_RUN** Tekton would be bumped from ${CURRENT_VERSION} to ${VERSION}"
+    exit 0
+fi
+
+sed -e -i "s/.Values.tekton.tag | default \"v[.0-9]*\"/.Values.tekton.tag | default \"v${VERSION}\"/g" ./chart/templates/deployment.yaml

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -25,15 +25,20 @@ sources:
         kind: semver
 
 targets:
-  values-yaml:
+  gitjob:
+    kind: shell
     name: 'Update build-tekton reference'
-    kind: file
-    spec:
-      file: chart/templates/deployment.yaml
-      matchpattern: '.Values.tekton.tag | default "(v{0,1})(\d)(.*)"'
-      replacepattern: '.Values.tekton.tag | default "{{ source "build-tekton" }}"'
-    scmid: gitjob
     sourceid: build-tekton
+    spec:
+      # gitjob source value is automatically added to the command as a parameter
+      command: "./updatecli/scripts/update_deployment.sh"
+      environments:
+        - name: PATH
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            -  chart/templates/deployment.yaml
 
 actions:
   default:


### PR DESCRIPTION
by using a script. The issue is that updatecli interprets the helm templates even during replacement.

Probably related to https://github.com/orgs/updatecli/discussions/1243