### PR TITLE
Bump Tekton to v0.1.22

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           - --debug
           {{- end }}
           - --tekton-image
-          - "{{ template "system_default_registry" . }}{{ .Values.tekton.repository }}:{{ .Values.tekton.tag | default "v0.1.21" }}"
+          - "{{ template "system_default_registry" . }}{{ .Values.tekton.repository }}:{{ .Values.tekton.tag | default "v0.1.22" }}"
           env:
             - name: NAMESPACE
               valueFrom:


### PR DESCRIPTION
## What's Changed
* Bump bci/bci-base from 15.4.27.14.56 to 15.4.27.14.60 in /package by @dependabot in https://github.com/rancher/build-tekton/pull/60


**Full Changelog**: https://github.com/rancher/build-tekton/compare/v0.1.21...v0.1.22