### PR TITLE
Add scmid to updatecli manifest target

### DIFF
--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -28,6 +28,7 @@ targets:
   gitjob:
     kind: shell
     name: 'Update build-tekton reference'
+    scmid: gitjob
     sourceid: build-tekton
     spec:
       # gitjob source value is automatically added to the command as a parameter


### PR DESCRIPTION
This setting is needed so updatecli can modifie the git repositoy instead of just the local