### PR TITLE
Add default TTL for jobs of 24h

### DIFF
--- a/pkg/controller/gitjob/gitjobs.go
+++ b/pkg/controller/gitjob/gitjobs.go
@@ -31,6 +31,7 @@ const (
 	bundleCAVolumeName = "additional-ca"
 	bundleCAFile       = "additional-ca.crt"
 	bundleDir          = "/etc/rancher/ssl"
+	defaultTTL         = 86400 // 24 hours
 )
 
 func Register(ctx context.Context, cont *types.Context) {
@@ -171,6 +172,11 @@ func (h Handler) generateJob(obj *v1.GitJob) (*batchv1.Job, error) {
 			Name:      jobName(obj),
 		},
 		Spec: obj.Spec.JobSpec,
+	}
+
+	if job.Spec.TTLSecondsAfterFinished == nil {
+		ttl := int32(defaultTTL)
+		job.Spec.TTLSecondsAfterFinished = &ttl
 	}
 
 	cloneContainer, err := h.generateCloneContainer(obj)


### PR DESCRIPTION
Since gitjob now retries failed jobs, we need a mechanism to allow automatic clean up.
We can make this configurable later.

See
* https://github.com/rancher/gitjob/issues/248
* https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/

