### PR TITLE
Fix gitrepo retry failed jobs

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func run(c *cli.Context) {
 	}
 	cfg.RateLimiter = ratelimit.None
 
-	ctx, cont := types.BuildContext(ctx, c.String("namespace"), cfg)
+	cont := types.BuildContext(c.String("namespace"), cfg)
 	if err := cont.Start(ctx); err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/controller/gitjob/gitjobs.go
+++ b/pkg/controller/gitjob/gitjobs.go
@@ -49,7 +49,9 @@ func Register(ctx context.Context, cont *types.Context) {
 	v1controller.RegisterGitJobGeneratingHandler(
 		ctx,
 		cont.Gitjob.Gitjob().V1().GitJob(),
-		cont.Apply.WithSetOwnerReference(true, false).WithCacheTypes(cont.Batch.Batch().V1().Job(), cont.Core.Core().V1().Secret()).WithPatcher(
+		cont.Apply.WithSetOwnerReference(true, false).
+			WithDynamicLookup().
+			WithCacheTypes(cont.Core.Core().V1().Secret()).WithPatcher(
 			batchv1.SchemeGroupVersion.WithKind("Job"),
 			func(namespace, name string, patchType types2.PatchType, data []byte) (runtime.Object, error) {
 				return nil, apply.ErrReplace

--- a/pkg/controller/gitjob/gitjobs.go
+++ b/pkg/controller/gitjob/gitjobs.go
@@ -49,13 +49,16 @@ func Register(ctx context.Context, cont *types.Context) {
 	v1controller.RegisterGitJobGeneratingHandler(
 		ctx,
 		cont.Gitjob.Gitjob().V1().GitJob(),
-		cont.Apply.WithSetOwnerReference(true, false).
+		cont.Apply.
+			WithSetOwnerReference(true, false).
 			WithDynamicLookup().
-			WithCacheTypes(cont.Core.Core().V1().Secret()).WithPatcher(
-			batchv1.SchemeGroupVersion.WithKind("Job"),
-			func(namespace, name string, patchType types2.PatchType, data []byte) (runtime.Object, error) {
-				return nil, apply.ErrReplace
-			}),
+			WithCacheTypes(cont.Core.Core().V1().Secret()).
+			WithPatcher(
+				batchv1.SchemeGroupVersion.WithKind("Job"),
+				func(namespace, name string, patchType types2.PatchType, data []byte) (runtime.Object, error) {
+					return nil, apply.ErrReplace
+				},
+			),
 		"Synced",
 		"sync-repo",
 		h.generate,

--- a/pkg/controller/gitjob/gitjobs.go
+++ b/pkg/controller/gitjob/gitjobs.go
@@ -31,7 +31,6 @@ const (
 	bundleCAVolumeName = "additional-ca"
 	bundleCAFile       = "additional-ca.crt"
 	bundleDir          = "/etc/rancher/ssl"
-	defaultTTL         = 86400 // 24 hours
 )
 
 func Register(ctx context.Context, cont *types.Context) {
@@ -172,11 +171,6 @@ func (h Handler) generateJob(obj *v1.GitJob) (*batchv1.Job, error) {
 			Name:      jobName(obj),
 		},
 		Spec: obj.Spec.JobSpec,
-	}
-
-	if job.Spec.TTLSecondsAfterFinished == nil {
-		ttl := int32(defaultTTL)
-		job.Spec.TTLSecondsAfterFinished = &ttl
 	}
 
 	cloneContainer, err := h.generateCloneContainer(obj)

--- a/pkg/controller/gitjob/gitjobs_test.go
+++ b/pkg/controller/gitjob/gitjobs_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Gitjob Controller", func() {
 		gitjob     *v1.GitJob
 		jobmock    *mocks.MockJobClient
 		gitjobmock *mocks.MockGitJobController
+		background = metav1.DeletePropagationBackground
 	)
 
 	defaultGitjob := func() *v1.GitJob {
@@ -89,7 +90,7 @@ var _ = Describe("Gitjob Controller", func() {
 			gitjob = defaultGitjob()
 			gitjob.Spec.ForceUpdateGeneration = 234
 			gitjob.Status.UpdateGeneration = 1
-			jobmock.EXPECT().Delete(gitjob.Namespace, jobName(gitjob), &metav1.DeleteOptions{}).Return(nil)
+			jobmock.EXPECT().Delete(gitjob.Namespace, jobName(gitjob), &metav1.DeleteOptions{PropagationPolicy: &background}).Return(nil)
 		})
 
 		It("deletes the job and updates update generation in status", func() {
@@ -105,7 +106,7 @@ var _ = Describe("Gitjob Controller", func() {
 		BeforeEach(func() {
 			gitjob = defaultGitjob()
 			kstatus.SetError(gitjob, `time="2023-07-19T10:48:12Z" level=fatal msg="Helm chart download: failed to authorize: failed to fetch anonymous token: unexpected status: 403 Forbidden"`)
-			jobmock.EXPECT().Delete(gitjob.Namespace, jobName(gitjob), &metav1.DeleteOptions{}).Return(nil)
+			jobmock.EXPECT().Delete(gitjob.Namespace, jobName(gitjob), &metav1.DeleteOptions{PropagationPolicy: &background}).Return(nil)
 		})
 
 		It("deletes the job", func() {

--- a/pkg/controller/job/jobs.go
+++ b/pkg/controller/job/jobs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/wrangler/pkg/condition"
 	corev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/pkg/kstatus"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	labels2 "k8s.io/apimachinery/pkg/labels"
@@ -58,6 +59,8 @@ func (j jobHandler) sync(_ string, obj *v1.Job) (*v1.Job, error) {
 			if strconv.Itoa(int(gitjob.Generation)) != obj.Annotations["generation"] {
 				continue
 			}
+			logrus.Debugf("Job change, syncing status for gitjob %s/%s: %s", gitjob.Namespace, gitjob.Name, result.Status.String())
+
 			gitjob.Status.JobStatus = result.Status.String()
 			for _, con := range result.Conditions {
 				condition.Cond(con.Type.String()).SetStatus(gitjob, string(con.Status))

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -57,6 +57,5 @@ func BuildContext(namespace string, config *rest.Config) *Context {
 		logrus.Fatal(err)
 	}
 
-	c := newContext(namespace, config)
-	return c
+	return newContext(namespace, config)
 }

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-type contextKey struct{}
-
 type Context struct {
 	Image     string
 	Namespace string
@@ -28,15 +26,7 @@ type Context struct {
 	Apply apply.Apply
 }
 
-func Store(ctx context.Context, c *Context) context.Context {
-	return context.WithValue(ctx, contextKey{}, c)
-}
-
-func From(ctx context.Context) *Context {
-	return ctx.Value(contextKey{}).(*Context)
-}
-
-func NewContext(namespace string, config *rest.Config) *Context {
+func newContext(namespace string, config *rest.Config) *Context {
 	context := &Context{
 		Namespace: namespace,
 		Batch:     batch.NewFactoryFromConfigOrDie(config),
@@ -44,8 +34,8 @@ func NewContext(namespace string, config *rest.Config) *Context {
 		Gitjob:    gitjob.NewFactoryFromConfigOrDie(config),
 		K8s:       kubernetes.NewForConfigOrDie(config),
 	}
-
 	context.Apply = apply.New(context.K8s.Discovery(), apply.NewClientFactory(config))
+
 	return context
 }
 
@@ -57,7 +47,7 @@ func (c *Context) Start(ctx context.Context) error {
 	)
 }
 
-func BuildContext(ctx context.Context, namespace string, config *rest.Config) (context.Context, *Context) {
+func BuildContext(namespace string, config *rest.Config) *Context {
 	factory, err := crd.NewFactoryFromClient(config)
 	if err != nil {
 		logrus.Fatal(err)
@@ -67,6 +57,6 @@ func BuildContext(ctx context.Context, namespace string, config *rest.Config) (c
 		logrus.Fatal(err)
 	}
 
-	c := NewContext(namespace, config)
-	return context.WithValue(ctx, contextKey{}, c), c
+	c := newContext(namespace, config)
+	return c
 }


### PR DESCRIPTION
Refers to https://github.com/rancher/fleet/issues/1387

Previous PR accumulated too many pods. This sets the propagation policy, which is required to delete a job's pods.

It seems a "apply", directly after a "Delete" is a "NoChange", however the job will be recreated after the next `syncInterval` (= `pollingInterval` in fleet). To fix this I removed the job cache from the apply.