### PR TITLE
Add git to gitjob image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/bci-base:15.5.36.5.47
 RUN zypper -n update && \
-    zypper -n install openssh catatonit && \
+    zypper -n install openssh catatonit git && \
     zypper -n clean -a
 RUN useradd -u 1000 -U -m gitjob
 COPY bin/gitjob /usr/bin/


### PR DESCRIPTION
`go-git` tries to use the `git` binary if a repository can't be found. This was causing misleading error messages. This PR adds the git binary to the `gitjob` image.

For example:
`git@github.com/go-git/go-git.git`  was returning the error `Error fetching latest commit: Exec: "git": executable file not found in $PATH`

With the changes from this PR the error is:
`Error fetching latest commit: repository not found`

refers to https://github.com/rancher/rancher/issues/43499