### PR TITLE
Switch to minor version bumping during automatic releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: rymndhng/release-on-push-action@master
         with:
-          bump_version_scheme: patch
+          bump_version_scheme: minor
           use_github_release_notes: true


### PR DESCRIPTION
to be able to release security fixes as patch releases.