### PR TITLE
Bump golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.51.2
+          version: v1.55
 
           args: --timeout=10m --config=.golangci.json
 


### PR DESCRIPTION
use the same golangci-lint version used in fleet