### PR TITLE
Add proxy env vars to job containers

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,7 +7,7 @@ ENV HELM_URL_V3=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
 
 RUN zypper -n install git docker vim wget jq
 RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2; \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.1; \
     fi
 RUN mkdir /usr/tmp && \
     curl ${HELM_URL_V3} | tar xvzf - --strip-components=1 -C /usr/tmp/ && \


### PR DESCRIPTION
`HTTP_PROXY`, `HTTPS_PROXY` env vars were not added to the `Job` generated by the `GitJob` controller since tekton was removed in https://github.com/rancher/gitjob/pull/302/files#diff-d8502e4f5b09fbcbcb9b11e66e4e2d72c33d0b70b2def399245866b80fc9d975L272 

This PR puts back those env vars in the `containers` and `initContainer` of the `Job`

Refers to https://github.com/rancher/fleet/issues/2017