### PR TITLE
Fix azure devops git clone error

### DIFF
--- a/cmd/gitcloner/gogit/cloner.go
+++ b/cmd/gitcloner/gogit/cloner.go
@@ -43,6 +43,9 @@ func (c *Cloner) CloneRepo(opts *cmd.Options) error {
 	// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
 	// which are not fully implemented and by default are included in
 	// transport.UnsupportedCapabilities.
+	// Public repos in Azure can't be cloned.
+	// This can be removed once go-git implements the git v2 protocol.
+	// https://github.com/go-git/go-git/issues/64
 	transport.UnsupportedCapabilities = []capability.Capability{
 		capability.ThinPack,
 	}

--- a/cmd/gitcloner/gogit/cloner.go
+++ b/cmd/gitcloner/gogit/cloner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	httpgit "github.com/go-git/go-git/v5/plumbing/transport/http"
 	gossh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
@@ -39,6 +40,12 @@ func NewCloner() *Cloner {
 }
 
 func (c *Cloner) CloneRepo(opts *cmd.Options) error {
+	// Azure DevOps requires capabilities multi_ack / multi_ack_detailed,
+	// which are not fully implemented and by default are included in
+	// transport.UnsupportedCapabilities.
+	transport.UnsupportedCapabilities = []capability.Capability{
+		capability.ThinPack,
+	}
 	auth, err := createAuthFromOpts(opts)
 	if err != nil {
 		return err

--- a/cmd/gitcloner/gogit/cloner_test.go
+++ b/cmd/gitcloner/gogit/cloner_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+
 	"github.com/go-git/go-git/v5"
 	httpgit "github.com/go-git/go-git/v5/plumbing/transport/http"
 	gossh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
@@ -171,6 +174,10 @@ udiSlDctMM/X3ZM2JN5M1rtAJ2WR3ZQtmWbOjZAbG2Eq
 
 			if !cmp.Equal(cloneOptsCalled, test.expectedCloneOpts, sshKeyComparer) {
 				t.Fatalf("expected options %v, got %v", test.expectedCloneOpts, cloneOptsCalled)
+			}
+
+			if !cmp.Equal(transport.UnsupportedCapabilities, []capability.Capability{capability.ThinPack}) {
+				t.Errorf("expected transport.UnsupportedCapabilities []capability.Capability{capability.ThinPack}, got %v", transport.UnsupportedCapabilities)
 			}
 		})
 	}

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,7 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod
 github.com/go-git/go-git/v5 v5.11.0 h1:XIZc1p+8YzypNr34itUfSvYJcv+eYdTnTvOZ2vD3cA4=
 github.com/go-git/go-git/v5 v5.11.0/go.mod h1:6GFcX2P3NM7FPBfpePbpLd21XxsgdAt+lKqXmCUiUCY=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.2.4 h1:QHVo+6stLbfJmYGkQ7uGHUCu5hnAFAj6mDe6Ea0SeOo=


### PR DESCRIPTION
Azure DevOps requires capabilities `multi_ack` / `multi_ack_detailed`, which are not fully implemented and by default are included in `transport.UnsupportedCapabilities`.

This PR modifies the `transport.UnsupportedCapabilities`, so that git repos from Azure DevOps can be cloned. See this [example](https://github.com/go-git/go-git/blob/master/_examples/azure_devops/main.go#L34), this [PR](https://github.com/go-git/go-git/pull/613) and this [issue](https://github.com/go-git/go-git/issues/64) for more info.

refers to https://github.com/rancher/fleet/issues/2047
backported from https://github.com/rancher/gitjob/pull/400