### PR TITLE
Run go generate with controller-gen 0.14

### DIFF
--- a/chart/crds/crds.yaml
+++ b/chart/crds/crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: gitjobs.gitjob.cattle.io
 spec:
   group: gitjob.cattle.io
@@ -19,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -75,169 +80,185 @@ spec:
                 description: Job template applied to git commit
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the
-                      startTime that the job may be continuously active before the
-                      system tries to terminate it; value must be positive integer.
-                      If a Job is suspended (at creation or through an update), this
-                      timer will effectively be stopped and reset when the Job is
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job
+                      may be continuously active before the system tries to terminate it; value
+                      must be positive integer. If a Job is suspended (at creation or through an
+                      update), this timer will effectively be stopped and reset when the Job is
                       resumed again.
                     format: int64
                     type: integer
                   backoffLimit:
-                    description: Specifies the number of retries before marking this
-                      job failed. Defaults to 6
+                    description: |-
+                      Specifies the number of retries before marking this job failed.
+                      Defaults to 6
                     format: int32
                     type: integer
                   backoffLimitPerIndex:
-                    description: Specifies the limit for the number of retries within
-                      an index before marking this index as failed. When enabled the
-                      number of failures per index is kept in the pod's batch.kubernetes.io/job-index-failure-count
-                      annotation. It can only be set when Job's completionMode=Indexed,
-                      and the Pod's restart policy is Never. The field is immutable.
+                    description: |-
+                      Specifies the limit for the number of retries within an
+                      index before marking this index as failed. When enabled the number of
+                      failures per index is kept in the pod's
+                      batch.kubernetes.io/job-index-failure-count annotation. It can only
+                      be set when Job's completionMode=Indexed, and the Pod's restart
+                      policy is Never. The field is immutable.
                       This field is alpha-level. It can be used when the `JobBackoffLimitPerIndex`
                       feature gate is enabled (disabled by default).
                     format: int32
                     type: integer
                   completionMode:
-                    description: "completionMode specifies how Pod completions are
-                      tracked. It can be `NonIndexed` (default) or `Indexed`. \n `NonIndexed`
-                      means that the Job is considered complete when there have been
-                      .spec.completions successfully completed Pods. Each Pod completion
-                      is homologous to each other. \n `Indexed` means that the Pods
-                      of a Job get an associated completion index from 0 to (.spec.completions
-                      - 1), available in the annotation batch.kubernetes.io/job-completion-index.
-                      The Job is considered complete when there is one successfully
-                      completed Pod for each index. When value is `Indexed`, .spec.completions
-                      must be specified and `.spec.parallelism` must be less than
-                      or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`,
-                      the Pod hostname takes the form `$(job-name)-$(index)`. \n More
-                      completion modes can be added in the future. If the Job controller
-                      observes a mode that it doesn't recognize, which is possible
-                      during upgrades due to version skew, the controller skips updates
-                      for the Job."
+                    description: |-
+                      completionMode specifies how Pod completions are tracked. It can be
+                      `NonIndexed` (default) or `Indexed`.
+
+
+                      `NonIndexed` means that the Job is considered complete when there have
+                      been .spec.completions successfully completed Pods. Each Pod completion is
+                      homologous to each other.
+
+
+                      `Indexed` means that the Pods of a
+                      Job get an associated completion index from 0 to (.spec.completions - 1),
+                      available in the annotation batch.kubernetes.io/job-completion-index.
+                      The Job is considered complete when there is one successfully completed Pod
+                      for each index.
+                      When value is `Indexed`, .spec.completions must be specified and
+                      `.spec.parallelism` must be less than or equal to 10^5.
+                      In addition, The Pod name takes the form
+                      `$(job-name)-$(index)-$(random-string)`,
+                      the Pod hostname takes the form `$(job-name)-$(index)`.
+
+
+                      More completion modes can be added in the future.
+                      If the Job controller observes a mode that it doesn't recognize, which
+                      is possible during upgrades due to version skew, the controller
+                      skips updates for the Job.
                     type: string
                   completions:
-                    description: 'Specifies the desired number of successfully finished
-                      pods the job should be run with.  Setting to null means that
-                      the success of any pod signals the success of all pods, and
-                      allows parallelism to have any positive value.  Setting to 1
-                      means that parallelism is limited to 1 and the success of that
-                      pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                    description: |-
+                      Specifies the desired number of successfully finished pods the
+                      job should be run with.  Setting to null means that the success of any
+                      pod signals the success of all pods, and allows parallelism to have any positive
+                      value.  Setting to 1 means that parallelism is limited to 1 and the success of that
+                      pod signals the success of the job.
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
                     format: int32
                     type: integer
                   manualSelector:
-                    description: 'manualSelector controls generation of pod labels
-                      and pod selectors. Leave `manualSelector` unset unless you are
-                      certain what you are doing. When false or unset, the system
-                      pick labels unique to this job and appends those labels to the
-                      pod template.  When true, the user is responsible for picking
-                      unique labels and specifying the selector.  Failure to pick
-                      a unique label may cause this and other jobs to not function
-                      correctly.  However, You may see `manualSelector=true` in jobs
-                      that were created with the old `extensions/v1beta1` API. More
-                      info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector'
+                    description: |-
+                      manualSelector controls generation of pod labels and pod selectors.
+                      Leave `manualSelector` unset unless you are certain what you are doing.
+                      When false or unset, the system pick labels unique to this job
+                      and appends those labels to the pod template.  When true,
+                      the user is responsible for picking unique labels and specifying
+                      the selector.  Failure to pick a unique label may cause this
+                      and other jobs to not function correctly.  However, You may see
+                      `manualSelector=true` in jobs that were created with the old `extensions/v1beta1`
+                      API.
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
                     type: boolean
                   maxFailedIndexes:
-                    description: Specifies the maximal number of failed indexes before
-                      marking the Job as failed, when backoffLimitPerIndex is set.
-                      Once the number of failed indexes exceeds this number the entire
-                      Job is marked as Failed and its execution is terminated. When
-                      left as null the job continues execution of all of its indexes
-                      and is marked with the `Complete` Job condition. It can only
-                      be specified when backoffLimitPerIndex is set. It can be null
-                      or up to completions. It is required and must be less than or
-                      equal to 10^4 when is completions greater than 10^5. This field
-                      is alpha-level. It can be used when the `JobBackoffLimitPerIndex`
+                    description: |-
+                      Specifies the maximal number of failed indexes before marking the Job as
+                      failed, when backoffLimitPerIndex is set. Once the number of failed
+                      indexes exceeds this number the entire Job is marked as Failed and its
+                      execution is terminated. When left as null the job continues execution of
+                      all of its indexes and is marked with the `Complete` Job condition.
+                      It can only be specified when backoffLimitPerIndex is set.
+                      It can be null or up to completions. It is required and must be
+                      less than or equal to 10^4 when is completions greater than 10^5.
+                      This field is alpha-level. It can be used when the `JobBackoffLimitPerIndex`
                       feature gate is enabled (disabled by default).
                     format: int32
                     type: integer
                   parallelism:
-                    description: 'Specifies the maximum desired number of pods the
-                      job should run at any given time. The actual number of pods
-                      running in steady state will be less than this number when ((.spec.completions
-                      - .status.successful) < .spec.parallelism), i.e. when the work
-                      left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                    description: |-
+                      Specifies the maximum desired number of pods the job should
+                      run at any given time. The actual number of pods running in steady state will
+                      be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
+                      i.e. when the work left to do is less than max parallelism.
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
                     format: int32
                     type: integer
                   podFailurePolicy:
-                    description: "Specifies the policy of handling failed pods. In
-                      particular, it allows to specify the set of actions and conditions
-                      which need to be satisfied to take the associated action. If
-                      empty, the default behaviour applies - the counter of failed
-                      pods, represented by the jobs's .status.failed field, is incremented
-                      and it is checked against the backoffLimit. This field cannot
-                      be used in combination with restartPolicy=OnFailure. \n This
-                      field is beta-level. It can be used when the `JobPodFailurePolicy`
-                      feature gate is enabled (enabled by default)."
+                    description: |-
+                      Specifies the policy of handling failed pods. In particular, it allows to
+                      specify the set of actions and conditions which need to be
+                      satisfied to take the associated action.
+                      If empty, the default behaviour applies - the counter of failed pods,
+                      represented by the jobs's .status.failed field, is incremented and it is
+                      checked against the backoffLimit. This field cannot be used in combination
+                      with restartPolicy=OnFailure.
+
+
+                      This field is beta-level. It can be used when the `JobPodFailurePolicy`
+                      feature gate is enabled (enabled by default).
                     properties:
                       rules:
-                        description: A list of pod failure policy rules. The rules
-                          are evaluated in order. Once a rule matches a Pod failure,
-                          the remaining of the rules are ignored. When no rule matches
-                          the Pod failure, the default handling applies - the counter
-                          of pod failures is incremented and it is checked against
+                        description: |-
+                          A list of pod failure policy rules. The rules are evaluated in order.
+                          Once a rule matches a Pod failure, the remaining of the rules are ignored.
+                          When no rule matches the Pod failure, the default handling applies - the
+                          counter of pod failures is incremented and it is checked against
                           the backoffLimit. At most 20 elements are allowed.
                         items:
-                          description: PodFailurePolicyRule describes how a pod failure
-                            is handled when the requirements are met. One of onExitCodes
-                            and onPodConditions, but not both, can be used in each
-                            rule.
+                          description: |-
+                            PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.
+                            One of onExitCodes and onPodConditions, but not both, can be used in each rule.
                           properties:
                             action:
-                              description: "Specifies the action taken on a pod failure
-                                when the requirements are satisfied. Possible values
-                                are: \n - FailJob: indicates that the pod's job is
-                                marked as Failed and all running pods are terminated.
-                                - FailIndex: indicates that the pod's index is marked
-                                as Failed and will not be restarted. This value is
-                                alpha-level. It can be used when the `JobBackoffLimitPerIndex`
-                                feature gate is enabled (disabled by default). - Ignore:
-                                indicates that the counter towards the .backoffLimit
-                                is not incremented and a replacement pod is created.
-                                - Count: indicates that the pod is handled in the
-                                default way - the counter towards the .backoffLimit
-                                is incremented. Additional values are considered to
-                                be added in the future. Clients should react to an
-                                unknown action by skipping the rule."
+                              description: |-
+                                Specifies the action taken on a pod failure when the requirements are satisfied.
+                                Possible values are:
+
+
+                                - FailJob: indicates that the pod's job is marked as Failed and all
+                                  running pods are terminated.
+                                - FailIndex: indicates that the pod's index is marked as Failed and will
+                                  not be restarted.
+                                  This value is alpha-level. It can be used when the
+                                  `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default).
+                                - Ignore: indicates that the counter towards the .backoffLimit is not
+                                  incremented and a replacement pod is created.
+                                - Count: indicates that the pod is handled in the default way - the
+                                  counter towards the .backoffLimit is incremented.
+                                Additional values are considered to be added in the future. Clients should
+                                react to an unknown action by skipping the rule.
                               type: string
                             onExitCodes:
                               description: Represents the requirement on the container
                                 exit codes.
                               properties:
                                 containerName:
-                                  description: Restricts the check for exit codes
-                                    to the container with the specified name. When
-                                    null, the rule applies to all containers. When
-                                    specified, it should match one the container or
-                                    initContainer names in the pod template.
+                                  description: |-
+                                    Restricts the check for exit codes to the container with the
+                                    specified name. When null, the rule applies to all containers.
+                                    When specified, it should match one the container or initContainer
+                                    names in the pod template.
                                   type: string
                                 operator:
-                                  description: "Represents the relationship between
-                                    the container exit code(s) and the specified values.
-                                    Containers completed with success (exit code 0)
-                                    are excluded from the requirement check. Possible
-                                    values are: \n - In: the requirement is satisfied
-                                    if at least one container exit code (might be
-                                    multiple if there are multiple containers not
-                                    restricted by the 'containerName' field) is in
-                                    the set of specified values. - NotIn: the requirement
-                                    is satisfied if at least one container exit code
-                                    (might be multiple if there are multiple containers
-                                    not restricted by the 'containerName' field) is
-                                    not in the set of specified values. Additional
-                                    values are considered to be added in the future.
-                                    Clients should react to an unknown operator by
-                                    assuming the requirement is not satisfied."
+                                  description: |-
+                                    Represents the relationship between the container exit code(s) and the
+                                    specified values. Containers completed with success (exit code 0) are
+                                    excluded from the requirement check. Possible values are:
+
+
+                                    - In: the requirement is satisfied if at least one container exit code
+                                      (might be multiple if there are multiple containers not restricted
+                                      by the 'containerName' field) is in the set of specified values.
+                                    - NotIn: the requirement is satisfied if at least one container exit code
+                                      (might be multiple if there are multiple containers not restricted
+                                      by the 'containerName' field) is not in the set of specified values.
+                                    Additional values are considered to be added in the future. Clients should
+                                    react to an unknown operator by assuming the requirement is not satisfied.
                                   type: string
                                 values:
-                                  description: Specifies the set of values. Each returned
-                                    container exit code (might be multiple in case
-                                    of multiple containers) is checked against this
-                                    set of values with respect to the operator. The
-                                    list of values must be ordered and must not contain
-                                    duplicates. Value '0' cannot be used for the In
-                                    operator. At least one element is required. At
-                                    most 255 elements are allowed.
+                                  description: |-
+                                    Specifies the set of values. Each returned container exit code (might be
+                                    multiple in case of multiple containers) is checked against this set of
+                                    values with respect to the operator. The list of values must be ordered
+                                    and must not contain duplicates. Value '0' cannot be used for the In operator.
+                                    At least one element is required. At most 255 elements are allowed.
                                   items:
                                     format: int32
                                     type: integer
@@ -248,27 +269,25 @@ spec:
                               - values
                               type: object
                             onPodConditions:
-                              description: Represents the requirement on the pod conditions.
-                                The requirement is represented as a list of pod condition
-                                patterns. The requirement is satisfied if at least
-                                one pattern matches an actual pod condition. At most
-                                20 elements are allowed.
+                              description: |-
+                                Represents the requirement on the pod conditions. The requirement is represented
+                                as a list of pod condition patterns. The requirement is satisfied if at
+                                least one pattern matches an actual pod condition. At most 20 elements are allowed.
                               items:
-                                description: PodFailurePolicyOnPodConditionsPattern
-                                  describes a pattern for matching an actual pod condition
-                                  type.
+                                description: |-
+                                  PodFailurePolicyOnPodConditionsPattern describes a pattern for matching
+                                  an actual pod condition type.
                                 properties:
                                   status:
-                                    description: Specifies the required Pod condition
-                                      status. To match a pod condition it is required
-                                      that the specified status equals the pod condition
-                                      status. Defaults to True.
+                                    description: |-
+                                      Specifies the required Pod condition status. To match a pod condition
+                                      it is required that the specified status equals the pod condition status.
+                                      Defaults to True.
                                     type: string
                                   type:
-                                    description: Specifies the required Pod condition
-                                      type. To match a pod condition it is required
-                                      that specified type equals the pod condition
-                                      type.
+                                    description: |-
+                                      Specifies the required Pod condition type. To match a pod condition
+                                      it is required that specified type equals the pod condition type.
                                     type: string
                                 required:
                                 - status
@@ -285,45 +304,48 @@ spec:
                     - rules
                     type: object
                   podReplacementPolicy:
-                    description: "podReplacementPolicy specifies when to create replacement
-                      Pods. Possible values are: - TerminatingOrFailed means that
-                      we recreate pods when they are terminating (has a metadata.deletionTimestamp)
-                      or failed. - Failed means to wait until a previously created
-                      Pod is fully terminated (has phase Failed or Succeeded) before
-                      creating a replacement Pod. \n When using podFailurePolicy,
-                      Failed is the the only allowed value. TerminatingOrFailed and
-                      Failed are allowed values when podFailurePolicy is not in use.
-                      This is an alpha field. Enable JobPodReplacementPolicy to be
-                      able to use this field."
+                    description: |-
+                      podReplacementPolicy specifies when to create replacement Pods.
+                      Possible values are:
+                      - TerminatingOrFailed means that we recreate pods
+                        when they are terminating (has a metadata.deletionTimestamp) or failed.
+                      - Failed means to wait until a previously created Pod is fully terminated (has phase
+                        Failed or Succeeded) before creating a replacement Pod.
+
+
+                      When using podFailurePolicy, Failed is the the only allowed value.
+                      TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
+                      This is an alpha field. Enable JobPodReplacementPolicy to be able to use this field.
                     type: string
                   selector:
-                    description: 'A label query over pods that should match the pod
-                      count. Normally, the system sets this field for you. More info:
-                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                    description: |-
+                      A label query over pods that should match the pod count.
+                      Normally, the system sets this field for you.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -335,42 +357,44 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   suspend:
-                    description: suspend specifies whether the Job controller should
-                      create Pods or not. If a Job is created with suspend set to
-                      true, no Pods are created by the Job controller. If a Job is
-                      suspended after creation (i.e. the flag goes from false to true),
-                      the Job controller will delete all active Pods associated with
-                      this Job. Users must design their workload to gracefully handle
-                      this. Suspending a Job will reset the StartTime field of the
-                      Job, effectively resetting the ActiveDeadlineSeconds timer too.
-                      Defaults to false.
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not. If
+                      a Job is created with suspend set to true, no Pods are created by the Job
+                      controller. If a Job is suspended after creation (i.e. the flag goes from
+                      false to true), the Job controller will delete all active Pods associated
+                      with this Job. Users must design their workload to gracefully handle this.
+                      Suspending a Job will reset the StartTime field of the Job, effectively
+                      resetting the ActiveDeadlineSeconds timer too. Defaults to false.
                     type: boolean
                   template:
-                    description: 'Describes the pod that will be created when executing
-                      a job. The only allowed template.spec.restartPolicy values are
-                      "Never" or "OnFailure". More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                    description: |-
+                      Describes the pod that will be created when executing a job.
+                      The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
+                      More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
                     properties:
                       metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                         type: object
                       spec:
-                        description: 'Specification of the desired behavior of the
-                          pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                        description: |-
+                          Specification of the desired behavior of the pod.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                         properties:
                           activeDeadlineSeconds:
-                            description: Optional duration in seconds the pod may
-                              be active on the node relative to StartTime before the
-                              system will actively try to mark it failed and kill
-                              associated containers. Value must be a positive integer.
+                            description: |-
+                              Optional duration in seconds the pod may be active on the node relative to
+                              StartTime before the system will actively try to mark it failed and kill associated containers.
+                              Value must be a positive integer.
                             format: int64
                             type: integer
                           affinity:
@@ -381,24 +405,20 @@ spec:
                                   for the pod.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
-                                      pods to nodes that satisfy the affinity expressions
-                                      specified by this field, but it may choose a
-                                      node that violates one or more of the expressions.
-                                      The node that is most preferred is the one with
-                                      the greatest sum of weights, i.e. for each node
-                                      that meets all of the scheduling requirements
-                                      (resource request, requiredDuringScheduling
-                                      affinity expressions, etc.), compute a sum by
-                                      iterating through the elements of this field
-                                      and adding "weight" to the sum if the node matches
-                                      the corresponding matchExpressions; the node(s)
-                                      with the highest sum are the most preferred.
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                      node(s) with the highest sum are the most preferred.
                                     items:
-                                      description: An empty preferred scheduling term
-                                        matches all objects with implicit weight 0
-                                        (i.e. it's a no-op). A null preferred scheduling
-                                        term matches no objects (i.e. is also a no-op).
+                                      description: |-
+                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                       properties:
                                         preference:
                                           description: A node selector term, associated
@@ -408,35 +428,26 @@ spec:
                                               description: A list of node selector
                                                 requirements by node's labels.
                                               items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
                                                 properties:
                                                   key:
                                                     description: The label key that
                                                       the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -449,35 +460,26 @@ spec:
                                               description: A list of node selector
                                                 requirements by node's fields.
                                               items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
                                                 properties:
                                                   key:
                                                     description: The label key that
                                                       the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -500,57 +502,46 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified
-                                      by this field are not met at scheduling time,
-                                      the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this
-                                      field cease to be met at some point during pod
-                                      execution (e.g. due to an update), the system
-                                      may or may not try to eventually evict the pod
-                                      from its node.
+                                    description: |-
+                                      If the affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to an update), the system
+                                      may or may not try to eventually evict the pod from its node.
                                     properties:
                                       nodeSelectorTerms:
                                         description: Required. A list of node selector
                                           terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector
-                                            term matches no objects. The requirements
-                                            of them are ANDed. The TopologySelectorTerm
-                                            type implements a subset of the NodeSelectorTerm.
+                                          description: |-
+                                            A null or empty node selector term matches no objects. The requirements of
+                                            them are ANDed.
+                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                           properties:
                                             matchExpressions:
                                               description: A list of node selector
                                                 requirements by node's labels.
                                               items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
                                                 properties:
                                                   key:
                                                     description: The label key that
                                                       the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -563,35 +554,26 @@ spec:
                                               description: A list of node selector
                                                 requirements by node's fields.
                                               items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
                                                 properties:
                                                   key:
                                                     description: The label key that
                                                       the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -614,20 +596,16 @@ spec:
                                   etc. as some other pod(s)).
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
-                                      pods to nodes that satisfy the affinity expressions
-                                      specified by this field, but it may choose a
-                                      node that violates one or more of the expressions.
-                                      The node that is most preferred is the one with
-                                      the greatest sum of weights, i.e. for each node
-                                      that meets all of the scheduling requirements
-                                      (resource request, requiredDuringScheduling
-                                      affinity expressions, etc.), compute a sum by
-                                      iterating through the elements of this field
-                                      and adding "weight" to the sum if the node has
-                                      pods which matches the corresponding podAffinityTerm;
-                                      the node(s) with the highest sum are the most
-                                      preferred.
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                      node(s) with the highest sum are the most preferred.
                                     items:
                                       description: The weights of all of the matched
                                         WeightedPodAffinityTerm fields are added per-node
@@ -646,11 +624,9 @@ spec:
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -658,23 +634,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -686,39 +655,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the
-                                                set of namespaces that the term applies
-                                                to. The term is applied to the union
-                                                of the namespaces selected by this
-                                                field and the ones listed in the namespaces
-                                                field. null selector and null or empty
-                                                namespaces list means "this pod's
-                                                namespace". An empty selector ({})
-                                                matches all namespaces.
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -726,23 +685,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -754,49 +706,37 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a
-                                                static list of namespace names that
-                                                the term applies to. The term is applied
-                                                to the union of the namespaces listed
-                                                in this field and the ones selected
-                                                by namespaceSelector. null or empty
-                                                namespaces list and null namespaceSelector
-                                                means "this pod's namespace".
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching
-                                            the corresponding podAffinityTerm, in
-                                            the range 1-100.
+                                          description: |-
+                                            weight associated with matching the corresponding podAffinityTerm,
+                                            in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -805,26 +745,22 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified
-                                      by this field are not met at scheduling time,
-                                      the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this
-                                      field cease to be met at some point during pod
-                                      execution (e.g. due to a pod label update),
-                                      the system may or may not try to eventually
-                                      evict the pod from its node. When there are
-                                      multiple elements, the lists of nodes corresponding
-                                      to each podAffinityTerm are intersected, i.e.
-                                      all terms must be satisfied.
+                                    description: |-
+                                      If the affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to a pod label update), the
+                                      system may or may not try to eventually evict the pod from its node.
+                                      When there are multiple elements, the lists of nodes corresponding to each
+                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
-                                      description: Defines a set of pods (namely those
-                                        matching the labelSelector relative to the
-                                        given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity)
-                                        with, where co-located is defined as running
-                                        on a node whose value of the label with key
-                                        <topologyKey> matches that of any node on
-                                        which a pod of the set of pods is running
+                                      description: |-
+                                        Defines a set of pods (namely those matching the labelSelector
+                                        relative to the given namespace(s)) that this pod should be
+                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                        where co-located is defined as running on a node whose value of
+                                        the label with key <topologyKey> matches that of any node on which
+                                        a pod of the set of pods is running
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
@@ -835,10 +771,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -846,20 +781,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -871,36 +802,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -908,20 +832,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -933,38 +853,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
@@ -977,20 +888,16 @@ spec:
                                   zone, etc. as some other pod(s)).
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
-                                      pods to nodes that satisfy the anti-affinity
-                                      expressions specified by this field, but it
-                                      may choose a node that violates one or more
-                                      of the expressions. The node that is most preferred
-                                      is the one with the greatest sum of weights,
-                                      i.e. for each node that meets all of the scheduling
-                                      requirements (resource request, requiredDuringScheduling
-                                      anti-affinity expressions, etc.), compute a
-                                      sum by iterating through the elements of this
-                                      field and adding "weight" to the sum if the
-                                      node has pods which matches the corresponding
-                                      podAffinityTerm; the node(s) with the highest
-                                      sum are the most preferred.
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the anti-affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                      node(s) with the highest sum are the most preferred.
                                     items:
                                       description: The weights of all of the matched
                                         WeightedPodAffinityTerm fields are added per-node
@@ -1009,11 +916,9 @@ spec:
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -1021,23 +926,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1049,39 +947,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the
-                                                set of namespaces that the term applies
-                                                to. The term is applied to the union
-                                                of the namespaces selected by this
-                                                field and the ones listed in the namespaces
-                                                field. null selector and null or empty
-                                                namespaces list means "this pod's
-                                                namespace". An empty selector ({})
-                                                matches all namespaces.
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -1089,23 +977,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1117,49 +998,37 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a
-                                                static list of namespace names that
-                                                the term applies to. The term is applied
-                                                to the union of the namespaces listed
-                                                in this field and the ones selected
-                                                by namespaceSelector. null or empty
-                                                namespaces list and null namespaceSelector
-                                                means "this pod's namespace".
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching
-                                            the corresponding podAffinityTerm, in
-                                            the range 1-100.
+                                          description: |-
+                                            weight associated with matching the corresponding podAffinityTerm,
+                                            in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -1168,26 +1037,22 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements
-                                      specified by this field are not met at scheduling
-                                      time, the pod will not be scheduled onto the
-                                      node. If the anti-affinity requirements specified
-                                      by this field cease to be met at some point
-                                      during pod execution (e.g. due to a pod label
-                                      update), the system may or may not try to eventually
-                                      evict the pod from its node. When there are
-                                      multiple elements, the lists of nodes corresponding
-                                      to each podAffinityTerm are intersected, i.e.
-                                      all terms must be satisfied.
+                                    description: |-
+                                      If the anti-affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the anti-affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to a pod label update), the
+                                      system may or may not try to eventually evict the pod from its node.
+                                      When there are multiple elements, the lists of nodes corresponding to each
+                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
-                                      description: Defines a set of pods (namely those
-                                        matching the labelSelector relative to the
-                                        given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity)
-                                        with, where co-located is defined as running
-                                        on a node whose value of the label with key
-                                        <topologyKey> matches that of any node on
-                                        which a pod of the set of pods is running
+                                      description: |-
+                                        Defines a set of pods (namely those matching the labelSelector
+                                        relative to the given namespace(s)) that this pod should be
+                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                        where co-located is defined as running on a node whose value of
+                                        the label with key <topologyKey> matches that of any node on which
+                                        a pod of the set of pods is running
                                       properties:
                                         labelSelector:
                                           description: A label query over a set of
@@ -1198,10 +1063,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -1209,20 +1073,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1234,36 +1094,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaceSelector:
-                                          description: A label query over the set
-                                            of namespaces that the term applies to.
-                                            The term is applied to the union of the
-                                            namespaces selected by this field and
-                                            the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces
-                                            list means "this pod's namespace". An
-                                            empty selector ({}) matches all namespaces.
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -1271,20 +1124,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1296,38 +1145,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: namespaces specifies a static
-                                            list of namespace names that the term
-                                            applies to. The term is applied to the
-                                            union of the namespaces listed in this
-                                            field and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace".
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
@@ -1340,47 +1180,45 @@ spec:
                               a service account token should be automatically mounted.
                             type: boolean
                           containers:
-                            description: List of containers belonging to the pod.
-                              Containers cannot currently be added or removed. There
-                              must be at least one container in a Pod. Cannot be updated.
+                            description: |-
+                              List of containers belonging to the pod.
+                              Containers cannot currently be added or removed.
+                              There must be at least one container in a Pod.
+                              Cannot be updated.
                             items:
                               description: A single application container that you
                                 want to run within a pod.
                               properties:
                                 args:
-                                  description: 'Arguments to the entrypoint. The container
-                                    image''s CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using
-                                    the container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. Double $$ are reduced to a
-                                    single $, which allows for escaping the $(VAR_NAME)
-                                    syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                    literal "$(VAR_NAME)". Escaped references will
-                                    never be expanded, regardless of whether the variable
-                                    exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The container image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The container image''s ENTRYPOINT is
-                                    used if this is not provided. Variable references
-                                    $(VAR_NAME) are expanded using the container''s
-                                    environment. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The container image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: List of environment variables to set
-                                    in the container. Cannot be updated.
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
                                   items:
                                     description: EnvVar represents an environment
                                       variable present in a Container.
@@ -1390,18 +1228,16 @@ spec:
                                           Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: 'Variable references $(VAR_NAME)
-                                          are expanded using the previously defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. Double
-                                          $$ are reduced to a single $, which allows
-                                          for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal
-                                          "$(VAR_NAME)". Escaped references will never
-                                          be expanded, regardless of whether the variable
-                                          exists or not. Defaults to "".'
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
                                         type: string
                                       valueFrom:
                                         description: Source for the environment variable's
@@ -1414,10 +1250,10 @@ spec:
                                                 description: The key to select.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -1428,11 +1264,9 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: 'Selects a field of the pod:
-                                              supports metadata.name, metadata.namespace,
-                                              `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
                                                 description: Version of the schema
@@ -1448,12 +1282,9 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -1486,10 +1317,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1505,15 +1336,13 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                    will be reported as an event when the container is starting. When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
                                   items:
                                     description: EnvFromSource represents the source
                                       of a set of ConfigMaps
@@ -1522,10 +1351,10 @@ spec:
                                         description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -1542,10 +1371,10 @@ spec:
                                         description: The Secret to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -1556,46 +1385,43 @@ spec:
                                     type: object
                                   type: array
                                 image:
-                                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config
-                                    management to default or override container images
-                                    in workload controllers like Deployments and StatefulSets.'
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                                 imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: Actions that the management system
-                                    should take in response to container lifecycle
-                                    events. Cannot be updated.
+                                  description: |-
+                                    Actions that the management system should take in response to container lifecycle events.
+                                    Cannot be updated.
                                   properties:
                                     postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
@@ -1605,10 +1431,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -1620,11 +1445,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -1643,25 +1466,24 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: Deprecated. TCPSocket is NOT
-                                            supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There
-                                            are no validation of this field and lifecycle
-                                            hooks will fail in runtime when tcp handler
-                                            is specified.
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for the backward compatibility. There are no validation of this field and
+                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1671,47 +1493,38 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The Pod''s termination grace
-                                        period countdown begins before the PreStop
-                                        hook is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period (unless delayed by finalizers). Other
-                                        management of the container blocks until the
-                                        hook completes or until the termination grace
-                                        period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
@@ -1721,10 +1534,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -1736,11 +1548,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -1759,25 +1569,24 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: Deprecated. TCPSocket is NOT
-                                            supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There
-                                            are no validation of this field and lifecycle
-                                            hooks will fail in runtime when tcp handler
-                                            is specified.
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for the backward compatibility. There are no validation of this field and
+                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1787,10 +1596,10 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -1798,33 +1607,30 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: 'Periodic probe of container liveness.
+                                  description: |-
+                                    Periodic probe of container liveness.
                                     Container will be restarted if the probe fails.
-                                    Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -1837,11 +1643,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -1851,8 +1658,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -1863,10 +1670,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -1884,35 +1690,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -1927,63 +1733,59 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: Name of the container specified as
-                                    a DNS_LABEL. Each container in a pod must have
-                                    a unique name (DNS_LABEL). Cannot be updated.
+                                  description: |-
+                                    Name of the container specified as a DNS_LABEL.
+                                    Each container in a pod must have a unique name (DNS_LABEL).
+                                    Cannot be updated.
                                   type: string
                                 ports:
-                                  description: List of ports to expose from the container.
-                                    Not specifying a port here DOES NOT prevent that
-                                    port from being exposed. Any port which is listening
-                                    on the default "0.0.0.0" address inside a container
-                                    will be accessible from the network. Modifying
-                                    this array with strategic merge patch may corrupt
-                                    the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  description: |-
+                                    List of ports to expose from the container. Not specifying a port here
+                                    DOES NOT prevent that port from being exposed. Any port which is
+                                    listening on the default "0.0.0.0" address inside a container will be
+                                    accessible from the network.
+                                    Modifying this array with strategic merge patch may corrupt the data.
+                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     Cannot be updated.
                                   items:
                                     description: ContainerPort represents a network
                                       port in a single container.
                                     properties:
                                       containerPort:
-                                        description: Number of port to expose on the
-                                          pod's IP address. This must be a valid port
-                                          number, 0 < x < 65536.
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
@@ -1991,24 +1793,24 @@ spec:
                                           port to.
                                         type: string
                                       hostPort:
-                                        description: Number of port to expose on the
-                                          host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
                                           Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: If specified, this must be an
-                                          IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: Protocol for port. Must be UDP,
-                                          TCP, or SCTP. Defaults to "TCP".
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -2019,34 +1821,30 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: 'Periodic probe of container service
-                                    readiness. Container will be removed from service
-                                    endpoints if the probe fails. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Periodic probe of container service readiness.
+                                    Container will be removed from service endpoints if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -2059,11 +1857,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -2073,8 +1872,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -2085,10 +1884,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -2106,35 +1904,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -2149,38 +1947,33 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
@@ -2191,14 +1984,14 @@ spec:
                                       resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: 'Name of the resource to which
-                                          this resource resize policy applies. Supported
-                                          values: cpu, memory.'
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: Restart policy to apply when
-                                          specified resource is resized. If not specified,
-                                          it defaults to NotRequired.
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -2207,26 +2000,31 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: 'Compute Resources required by this
-                                    container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Compute Resources required by this container.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   properties:
                                     claims:
-                                      description: "Claims lists the names of resources,
-                                        defined in spec.resourceClaims, that are used
-                                        by this container. \n This is an alpha field
-                                        and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+
+                                        This is an alpha field and requires enabling the
+                                        DynamicResourceAllocation feature gate.
+
+
+                                        This field is immutable. It can only be set for containers.
                                       items:
                                         description: ResourceClaim references one
                                           entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: Name must match the name
-                                              of one entry in pod.spec.resourceClaims
-                                              of the Pod where this field is used.
-                                              It makes that resource available inside
-                                              a container.
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -2242,8 +2040,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -2252,61 +2051,52 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: 'RestartPolicy defines the restart
-                                    behavior of individual containers in a pod. This
-                                    field may only be set for init containers, and
-                                    the only allowed value is "Always". For non-init
-                                    containers or when this field is not specified,
-                                    the restart behavior is defined by the Pod''s
-                                    restart policy and the container type. Setting
-                                    the RestartPolicy as "Always" for the init container
-                                    will have the following effect: this init container
-                                    will be continually restarted on exit until all
-                                    regular containers have terminated. Once all regular
-                                    containers have completed, all init containers
-                                    with restartPolicy "Always" will be shut down.
-                                    This lifecycle differs from normal init containers
-                                    and is often referred to as a "sidecar" container.
-                                    Although this init container still starts in the
-                                    init container sequence, it does not wait for
-                                    the container to complete before proceeding to
-                                    the next init container. Instead, the next init
-                                    container starts immediately after this init container
-                                    is started, or after any startupProbe has successfully
-                                    completed.'
+                                  description: |-
+                                    RestartPolicy defines the restart behavior of individual containers in a pod.
+                                    This field may only be set for init containers, and the only allowed value is "Always".
+                                    For non-init containers or when this field is not specified,
+                                    the restart behavior is defined by the Pod's restart policy and the container type.
+                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                    this init container will be continually restarted on
+                                    exit until all regular containers have terminated. Once all regular
+                                    containers have completed, all init containers with restartPolicy "Always"
+                                    will be shut down. This lifecycle differs from normal init containers and
+                                    is often referred to as a "sidecar" container. Although this init
+                                    container still starts in the init container sequence, it does not wait
+                                    for the container to complete before proceeding to the next init
+                                    container. Instead, the next init container starts immediately after this
+                                    init container is started, or after any startupProbe has successfully
+                                    completed.
                                   type: string
                                 securityContext:
-                                  description: 'SecurityContext defines the security
-                                    options the container should be run with. If set,
-                                    the fields of SecurityContext override the equivalent
-                                    fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                  description: |-
+                                    SecurityContext defines the security options the container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
-                                        whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.'
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime. Note that this field cannot be set
-                                        when spec.os.name is windows.
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
                                           description: Added capabilities
@@ -2324,69 +2114,60 @@ spec:
                                           type: array
                                       type: object
                                     privileged:
-                                      description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false. Note that this field cannot be set
-                                        when spec.os.name is windows.
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled. Note that this field cannot
-                                        be set when spec.os.name is windows.
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default is DefaultProcMount which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only
-                                        root filesystem. Default is false. Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: The GID to run the entrypoint of
-                                        the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is windows.
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is windows.
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
                                           description: Level is SELinux level label
@@ -2406,112 +2187,93 @@ spec:
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: The seccomp options to use by this
-                                        container. If seccomp options are provided
-                                        at both the pod & container level, the container
-                                        options override the pod options. Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: localhostProfile indicates
-                                            a profile defined in a file on the node
-                                            should be used. The profile must be preconfigured
-                                            on the node to work. Must be a descending
-                                            path, relative to the kubelet's configured
-                                            seccomp profile location. Must be set
-                                            if type is "Localhost". Must NOT be set
-                                            for any other type.
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: "type indicates which kind
-                                            of seccomp profile will be applied. Valid
-                                            options are: \n Localhost - a profile
-                                            defined in a file on the node should be
-                                            used. RuntimeDefault - the container runtime
-                                            default profile should be used. Unconfined
-                                            - no profile should be applied."
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is linux.
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field.
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
                                           description: GMSACredentialSpecName is the
                                             name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: HostProcess determines if a
-                                            container should be run as a 'Host Process'
-                                            container. All of a Pod's containers must
-                                            have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess
-                                            containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then
-                                            HostNetwork must also be set to true.
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: The UserName in Windows to
-                                            run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: 'StartupProbe indicates that the Pod
-                                    has successfully initialized. If specified, no
-                                    other probes are executed until this completes
-                                    successfully. If this probe fails, the Pod will
-                                    be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters
-                                    at the beginning of a Pod''s lifecycle, when it
-                                    might take a long time to load data or warm a
-                                    cache, than during steady-state operation. This
-                                    cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    StartupProbe indicates that the Pod has successfully initialized.
+                                    If specified, no other probes are executed until this completes successfully.
+                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                    This cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -2524,11 +2286,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -2538,8 +2301,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -2550,10 +2313,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -2571,35 +2333,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -2614,87 +2376,76 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: Whether the container runtime should
-                                    close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
                                   type: boolean
                                 terminationMessagePath:
-                                  description: 'Optional: Path at which the file to
-                                    which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: Whether this container should allocate
-                                    a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
                                   type: boolean
                                 volumeDevices:
                                   description: volumeDevices is the list of block
@@ -2718,46 +2469,45 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: Pod volumes to mount into the container's
-                                    filesystem. Cannot be updated.
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem.
+                                    Cannot be updated.
                                   items:
                                     description: VolumeMount describes a mounting
                                       of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at
-                                          which the volume should be mounted.  Must
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
                                           not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how
-                                          mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
                                         type: string
                                       name:
                                         description: This must match the Name of a
                                           Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write
-                                          otherwise (false or unspecified). Defaults
-                                          to false.
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which
-                                          the container's volume should be mounted.
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
                                           Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume
-                                          from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -2765,33 +2515,36 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           dnsConfig:
-                            description: Specifies the DNS parameters of a pod. Parameters
-                              specified here will be merged to the generated DNS configuration
-                              based on DNSPolicy.
+                            description: |-
+                              Specifies the DNS parameters of a pod.
+                              Parameters specified here will be merged to the generated DNS
+                              configuration based on DNSPolicy.
                             properties:
                               nameservers:
-                                description: A list of DNS name server IP addresses.
-                                  This will be appended to the base nameservers generated
-                                  from DNSPolicy. Duplicated nameservers will be removed.
+                                description: |-
+                                  A list of DNS name server IP addresses.
+                                  This will be appended to the base nameservers generated from DNSPolicy.
+                                  Duplicated nameservers will be removed.
                                 items:
                                   type: string
                                 type: array
                               options:
-                                description: A list of DNS resolver options. This
-                                  will be merged with the base options generated from
-                                  DNSPolicy. Duplicated entries will be removed. Resolution
-                                  options given in Options will override those that
-                                  appear in the base DNSPolicy.
+                                description: |-
+                                  A list of DNS resolver options.
+                                  This will be merged with the base options generated from DNSPolicy.
+                                  Duplicated entries will be removed. Resolution options given in Options
+                                  will override those that appear in the base DNSPolicy.
                                 items:
                                   description: PodDNSConfigOption defines DNS resolver
                                     options of a pod.
@@ -2804,82 +2557,77 @@ spec:
                                   type: object
                                 type: array
                               searches:
-                                description: A list of DNS search domains for host-name
-                                  lookup. This will be appended to the base search
-                                  paths generated from DNSPolicy. Duplicated search
-                                  paths will be removed.
+                                description: |-
+                                  A list of DNS search domains for host-name lookup.
+                                  This will be appended to the base search paths generated from DNSPolicy.
+                                  Duplicated search paths will be removed.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           dnsPolicy:
-                            description: Set DNS policy for the pod. Defaults to "ClusterFirst".
-                              Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
-                              'Default' or 'None'. DNS parameters given in DNSConfig
-                              will be merged with the policy selected with DNSPolicy.
-                              To have DNS options set along with hostNetwork, you
-                              have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                            description: |-
+                              Set DNS policy for the pod.
+                              Defaults to "ClusterFirst".
+                              Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                              DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                              To have DNS options set along with hostNetwork, you have to specify DNS policy
+                              explicitly to 'ClusterFirstWithHostNet'.
                             type: string
                           enableServiceLinks:
-                            description: 'EnableServiceLinks indicates whether information
-                              about services should be injected into pod''s environment
-                              variables, matching the syntax of Docker links. Optional:
-                              Defaults to true.'
+                            description: |-
+                              EnableServiceLinks indicates whether information about services should be injected into pod's
+                              environment variables, matching the syntax of Docker links.
+                              Optional: Defaults to true.
                             type: boolean
                           ephemeralContainers:
-                            description: List of ephemeral containers run in this
-                              pod. Ephemeral containers may be run in an existing
-                              pod to perform user-initiated actions such as debugging.
-                              This list cannot be specified when creating a pod, and
-                              it cannot be modified by updating the pod spec. In order
-                              to add an ephemeral container to an existing pod, use
-                              the pod's ephemeralcontainers subresource.
+                            description: |-
+                              List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                              pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                              creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                              ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                             items:
-                              description: "An EphemeralContainer is a temporary container
-                                that you may add to an existing Pod for user-initiated
-                                activities such as debugging. Ephemeral containers
-                                have no resource or scheduling guarantees, and they
-                                will not be restarted when they exit or when a Pod
-                                is removed or restarted. The kubelet may evict a Pod
-                                if an ephemeral container causes the Pod to exceed
-                                its resource allocation. \n To add an ephemeral container,
-                                use the ephemeralcontainers subresource of an existing
-                                Pod. Ephemeral containers may not be removed or restarted."
+                              description: |-
+                                An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                Pod to exceed its resource allocation.
+
+
+                                To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                Pod. Ephemeral containers may not be removed or restarted.
                               properties:
                                 args:
-                                  description: 'Arguments to the entrypoint. The image''s
-                                    CMD is used if this is not provided. Variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. Double $$ are reduced to a
-                                    single $, which allows for escaping the $(VAR_NAME)
-                                    syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                    literal "$(VAR_NAME)". Escaped references will
-                                    never be expanded, regardless of whether the variable
-                                    exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The image''s ENTRYPOINT is used if this
-                                    is not provided. Variable references $(VAR_NAME)
-                                    are expanded using the container''s environment.
-                                    If a variable cannot be resolved, the reference
-                                    in the input string will be unchanged. Double
-                                    $$ are reduced to a single $, which allows for
-                                    escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: List of environment variables to set
-                                    in the container. Cannot be updated.
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
                                   items:
                                     description: EnvVar represents an environment
                                       variable present in a Container.
@@ -2889,18 +2637,16 @@ spec:
                                           Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: 'Variable references $(VAR_NAME)
-                                          are expanded using the previously defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. Double
-                                          $$ are reduced to a single $, which allows
-                                          for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal
-                                          "$(VAR_NAME)". Escaped references will never
-                                          be expanded, regardless of whether the variable
-                                          exists or not. Defaults to "".'
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
                                         type: string
                                       valueFrom:
                                         description: Source for the environment variable's
@@ -2913,10 +2659,10 @@ spec:
                                                 description: The key to select.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -2927,11 +2673,9 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: 'Selects a field of the pod:
-                                              supports metadata.name, metadata.namespace,
-                                              `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
                                                 description: Version of the schema
@@ -2947,12 +2691,9 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -2985,10 +2726,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3004,15 +2745,13 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                    will be reported as an event when the container is starting. When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
                                   items:
                                     description: EnvFromSource represents the source
                                       of a set of ConfigMaps
@@ -3021,10 +2760,10 @@ spec:
                                         description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -3041,10 +2780,10 @@ spec:
                                         description: The Secret to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -3055,42 +2794,40 @@ spec:
                                     type: object
                                   type: array
                                 image:
-                                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
                                   type: string
                                 imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
                                   description: Lifecycle is not allowed for ephemeral
                                     containers.
                                   properties:
                                     postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
@@ -3100,10 +2837,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3115,11 +2851,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -3138,25 +2872,24 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: Deprecated. TCPSocket is NOT
-                                            supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There
-                                            are no validation of this field and lifecycle
-                                            hooks will fail in runtime when tcp handler
-                                            is specified.
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for the backward compatibility. There are no validation of this field and
+                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3166,47 +2899,38 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The Pod''s termination grace
-                                        period countdown begins before the PreStop
-                                        hook is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period (unless delayed by finalizers). Other
-                                        management of the container blocks until the
-                                        hook completes or until the termination grace
-                                        period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
@@ -3216,10 +2940,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3231,11 +2954,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -3254,25 +2975,24 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: Deprecated. TCPSocket is NOT
-                                            supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There
-                                            are no validation of this field and lifecycle
-                                            hooks will fail in runtime when tcp handler
-                                            is specified.
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for the backward compatibility. There are no validation of this field and
+                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3282,10 +3002,10 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -3300,25 +3020,20 @@ spec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -3331,11 +3046,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -3345,8 +3061,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -3357,10 +3073,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -3378,35 +3093,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -3421,46 +3136,40 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: Name of the ephemeral container specified
-                                    as a DNS_LABEL. This name must be unique among
-                                    all containers, init containers and ephemeral
-                                    containers.
+                                  description: |-
+                                    Name of the ephemeral container specified as a DNS_LABEL.
+                                    This name must be unique among all containers, init containers and ephemeral containers.
                                   type: string
                                 ports:
                                   description: Ports are not allowed for ephemeral
@@ -3470,9 +3179,9 @@ spec:
                                       port in a single container.
                                     properties:
                                       containerPort:
-                                        description: Number of port to expose on the
-                                          pod's IP address. This must be a valid port
-                                          number, 0 < x < 65536.
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
@@ -3480,24 +3189,24 @@ spec:
                                           port to.
                                         type: string
                                       hostPort:
-                                        description: Number of port to expose on the
-                                          host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
                                           Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: If specified, this must be an
-                                          IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: Protocol for port. Must be UDP,
-                                          TCP, or SCTP. Defaults to "TCP".
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -3515,25 +3224,20 @@ spec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -3546,11 +3250,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -3560,8 +3265,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -3572,10 +3277,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -3593,35 +3297,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -3636,38 +3340,33 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
@@ -3678,14 +3377,14 @@ spec:
                                       resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: 'Name of the resource to which
-                                          this resource resize policy applies. Supported
-                                          values: cpu, memory.'
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: Restart policy to apply when
-                                          specified resource is resized. If not specified,
-                                          it defaults to NotRequired.
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -3694,27 +3393,30 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: Resources are not allowed for ephemeral
-                                    containers. Ephemeral containers use spare resources
+                                  description: |-
+                                    Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                     already allocated to the pod.
                                   properties:
                                     claims:
-                                      description: "Claims lists the names of resources,
-                                        defined in spec.resourceClaims, that are used
-                                        by this container. \n This is an alpha field
-                                        and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+
+                                        This is an alpha field and requires enabling the
+                                        DynamicResourceAllocation feature gate.
+
+
+                                        This field is immutable. It can only be set for containers.
                                       items:
                                         description: ResourceClaim references one
                                           entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: Name must match the name
-                                              of one entry in pod.spec.resourceClaims
-                                              of the Pod where this field is used.
-                                              It makes that resource available inside
-                                              a container.
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -3730,8 +3432,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3740,43 +3443,40 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: Restart policy for the container to
-                                    manage the restart behavior of each container
-                                    within a pod. This may only be set for init containers.
-                                    You cannot set this field on ephemeral containers.
+                                  description: |-
+                                    Restart policy for the container to manage the restart behavior of each
+                                    container within a pod.
+                                    This may only be set for init containers. You cannot set this field on
+                                    ephemeral containers.
                                   type: string
                                 securityContext:
-                                  description: 'Optional: SecurityContext defines
-                                    the security options the ephemeral container should
-                                    be run with. If set, the fields of SecurityContext
-                                    override the equivalent fields of PodSecurityContext.'
+                                  description: |-
+                                    Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
-                                        whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.'
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime. Note that this field cannot be set
-                                        when spec.os.name is windows.
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
                                           description: Added capabilities
@@ -3794,69 +3494,60 @@ spec:
                                           type: array
                                       type: object
                                     privileged:
-                                      description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false. Note that this field cannot be set
-                                        when spec.os.name is windows.
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled. Note that this field cannot
-                                        be set when spec.os.name is windows.
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default is DefaultProcMount which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only
-                                        root filesystem. Default is false. Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: The GID to run the entrypoint of
-                                        the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is windows.
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is windows.
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
                                           description: Level is SELinux level label
@@ -3876,74 +3567,62 @@ spec:
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: The seccomp options to use by this
-                                        container. If seccomp options are provided
-                                        at both the pod & container level, the container
-                                        options override the pod options. Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: localhostProfile indicates
-                                            a profile defined in a file on the node
-                                            should be used. The profile must be preconfigured
-                                            on the node to work. Must be a descending
-                                            path, relative to the kubelet's configured
-                                            seccomp profile location. Must be set
-                                            if type is "Localhost". Must NOT be set
-                                            for any other type.
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: "type indicates which kind
-                                            of seccomp profile will be applied. Valid
-                                            options are: \n Localhost - a profile
-                                            defined in a file on the node should be
-                                            used. RuntimeDefault - the container runtime
-                                            default profile should be used. Unconfined
-                                            - no profile should be applied."
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is linux.
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field.
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
                                           description: GMSACredentialSpecName is the
                                             name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: HostProcess determines if a
-                                            container should be run as a 'Host Process'
-                                            container. All of a Pod's containers must
-                                            have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess
-                                            containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then
-                                            HostNetwork must also be set to true.
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: The UserName in Windows to
-                                            run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
@@ -3955,25 +3634,20 @@ spec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -3986,11 +3660,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -4000,8 +3675,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -4012,10 +3687,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -4033,35 +3707,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -4076,98 +3750,86 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: Whether the container runtime should
-                                    close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
                                   type: boolean
                                 targetContainerName:
-                                  description: "If set, the name of the container
-                                    from PodSpec that this ephemeral container targets.
-                                    The ephemeral container will be run in the namespaces
-                                    (IPC, PID, etc) of this container. If not set
-                                    then the ephemeral container uses the namespaces
-                                    configured in the Pod spec. \n The container runtime
-                                    must implement support for this feature. If the
-                                    runtime does not support namespace targeting then
-                                    the result of setting this field is undefined."
+                                  description: |-
+                                    If set, the name of the container from PodSpec that this ephemeral container targets.
+                                    The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                    If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                    The container runtime must implement support for this feature. If the runtime does not
+                                    support namespace targeting then the result of setting this field is undefined.
                                   type: string
                                 terminationMessagePath:
-                                  description: 'Optional: Path at which the file to
-                                    which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: Whether this container should allocate
-                                    a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
                                   type: boolean
                                 volumeDevices:
                                   description: volumeDevices is the list of block
@@ -4191,47 +3853,45 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: Pod volumes to mount into the container's
-                                    filesystem. Subpath mounts are not allowed for
-                                    ephemeral containers. Cannot be updated.
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                    Cannot be updated.
                                   items:
                                     description: VolumeMount describes a mounting
                                       of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at
-                                          which the volume should be mounted.  Must
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
                                           not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how
-                                          mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
                                         type: string
                                       name:
                                         description: This must match the Name of a
                                           Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write
-                                          otherwise (false or unspecified). Defaults
-                                          to false.
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which
-                                          the container's volume should be mounted.
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
                                           Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume
-                                          from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -4239,24 +3899,24 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           hostAliases:
-                            description: HostAliases is an optional list of hosts
-                              and IPs that will be injected into the pod's hosts file
-                              if specified. This is only valid for non-hostNetwork
-                              pods.
+                            description: |-
+                              HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                              file if specified. This is only valid for non-hostNetwork pods.
                             items:
-                              description: HostAlias holds the mapping between IP
-                                and hostnames that will be injected as an entry in
-                                the pod's hosts file.
+                              description: |-
+                                HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                pod's hosts file.
                               properties:
                                 hostnames:
                                   description: Hostnames for the above IP address.
@@ -4269,111 +3929,106 @@ spec:
                               type: object
                             type: array
                           hostIPC:
-                            description: 'Use the host''s ipc namespace. Optional:
-                              Default to false.'
+                            description: |-
+                              Use the host's ipc namespace.
+                              Optional: Default to false.
                             type: boolean
                           hostNetwork:
-                            description: Host networking requested for this pod. Use
-                              the host's network namespace. If this option is set,
-                              the ports that will be used must be specified. Default
-                              to false.
+                            description: |-
+                              Host networking requested for this pod. Use the host's network namespace.
+                              If this option is set, the ports that will be used must be specified.
+                              Default to false.
                             type: boolean
                           hostPID:
-                            description: 'Use the host''s pid namespace. Optional:
-                              Default to false.'
+                            description: |-
+                              Use the host's pid namespace.
+                              Optional: Default to false.
                             type: boolean
                           hostUsers:
-                            description: 'Use the host''s user namespace. Optional:
-                              Default to true. If set to true or not present, the
-                              pod will be run in the host user namespace, useful for
-                              when the pod needs a feature only available to the host
-                              user namespace, such as loading a kernel module with
-                              CAP_SYS_MODULE. When set to false, a new userns is created
-                              for the pod. Setting false is useful for mitigating
-                              container breakout vulnerabilities even allowing users
-                              to run their containers as root without actually having
-                              root privileges on the host. This field is alpha-level
-                              and is only honored by servers that enable the UserNamespacesSupport
-                              feature.'
+                            description: |-
+                              Use the host's user namespace.
+                              Optional: Default to true.
+                              If set to true or not present, the pod will be run in the host user namespace, useful
+                              for when the pod needs a feature only available to the host user namespace, such as
+                              loading a kernel module with CAP_SYS_MODULE.
+                              When set to false, a new userns is created for the pod. Setting false is useful for
+                              mitigating container breakout vulnerabilities even allowing users to run their
+                              containers as root without actually having root privileges on the host.
+                              This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                             type: boolean
                           hostname:
-                            description: Specifies the hostname of the Pod If not
-                              specified, the pod's hostname will be set to a system-defined
-                              value.
+                            description: |-
+                              Specifies the hostname of the Pod
+                              If not specified, the pod's hostname will be set to a system-defined value.
                             type: string
                           imagePullSecrets:
-                            description: 'ImagePullSecrets is an optional list of
-                              references to secrets in the same namespace to use for
-                              pulling any of the images used by this PodSpec. If specified,
-                              these secrets will be passed to individual puller implementations
-                              for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                            description: |-
+                              ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                              If specified, these secrets will be passed to individual puller implementations for them to use.
+                              More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                             items:
-                              description: LocalObjectReference contains enough information
-                                to let you locate the referenced object inside the
-                                same namespace.
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             type: array
                           initContainers:
-                            description: 'List of initialization containers belonging
-                              to the pod. Init containers are executed in order prior
-                              to containers being started. If any init container fails,
-                              the pod is considered to have failed and is handled
-                              according to its restartPolicy. The name for an init
-                              container or normal container must be unique among all
-                              containers. Init containers may not have Lifecycle actions,
-                              Readiness probes, Liveness probes, or Startup probes.
-                              The resourceRequirements of an init container are taken
-                              into account during scheduling by finding the highest
-                              request/limit for each resource type, and then using
-                              the max of of that value or the sum of the normal containers.
-                              Limits are applied to init containers in a similar fashion.
+                            description: |-
+                              List of initialization containers belonging to the pod.
+                              Init containers are executed in order prior to containers being started. If any
+                              init container fails, the pod is considered to have failed and is handled according
+                              to its restartPolicy. The name for an init container or normal container must be
+                              unique among all containers.
+                              Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                              The resourceRequirements of an init container are taken into account during scheduling
+                              by finding the highest request/limit for each resource type, and then using the max of
+                              of that value or the sum of the normal containers. Limits are applied to init containers
+                              in a similar fashion.
                               Init containers cannot currently be added or removed.
-                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                             items:
                               description: A single application container that you
                                 want to run within a pod.
                               properties:
                                 args:
-                                  description: 'Arguments to the entrypoint. The container
-                                    image''s CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using
-                                    the container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. Double $$ are reduced to a
-                                    single $, which allows for escaping the $(VAR_NAME)
-                                    syntax: i.e. "$$(VAR_NAME)" will produce the string
-                                    literal "$(VAR_NAME)". Escaped references will
-                                    never be expanded, regardless of whether the variable
-                                    exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The container image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The container image''s ENTRYPOINT is
-                                    used if this is not provided. Variable references
-                                    $(VAR_NAME) are expanded using the container''s
-                                    environment. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The container image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: List of environment variables to set
-                                    in the container. Cannot be updated.
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
                                   items:
                                     description: EnvVar represents an environment
                                       variable present in a Container.
@@ -4383,18 +4038,16 @@ spec:
                                           Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: 'Variable references $(VAR_NAME)
-                                          are expanded using the previously defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. Double
-                                          $$ are reduced to a single $, which allows
-                                          for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal
-                                          "$(VAR_NAME)". Escaped references will never
-                                          be expanded, regardless of whether the variable
-                                          exists or not. Defaults to "".'
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
                                         type: string
                                       valueFrom:
                                         description: Source for the environment variable's
@@ -4407,10 +4060,10 @@ spec:
                                                 description: The key to select.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -4421,11 +4074,9 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: 'Selects a field of the pod:
-                                              supports metadata.name, metadata.namespace,
-                                              `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
                                                 description: Version of the schema
@@ -4441,12 +4092,9 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -4479,10 +4127,10 @@ spec:
                                                   secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4498,15 +4146,13 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                    will be reported as an event when the container is starting. When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
                                   items:
                                     description: EnvFromSource represents the source
                                       of a set of ConfigMaps
@@ -4515,10 +4161,10 @@ spec:
                                         description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the ConfigMap
@@ -4535,10 +4181,10 @@ spec:
                                         description: The Secret to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
                                             description: Specify whether the Secret
@@ -4549,46 +4195,43 @@ spec:
                                     type: object
                                   type: array
                                 image:
-                                  description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config
-                                    management to default or override container images
-                                    in workload controllers like Deployments and StatefulSets.'
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                                 imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: Actions that the management system
-                                    should take in response to container lifecycle
-                                    events. Cannot be updated.
+                                  description: |-
+                                    Actions that the management system should take in response to container lifecycle events.
+                                    Cannot be updated.
                                   properties:
                                     postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
@@ -4598,10 +4241,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -4613,11 +4255,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -4636,25 +4276,24 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: Deprecated. TCPSocket is NOT
-                                            supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There
-                                            are no validation of this field and lifecycle
-                                            hooks will fail in runtime when tcp handler
-                                            is specified.
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for the backward compatibility. There are no validation of this field and
+                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4664,47 +4303,38 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The Pod''s termination grace
-                                        period countdown begins before the PreStop
-                                        hook is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period (unless delayed by finalizers). Other
-                                        management of the container blocks until the
-                                        hook completes or until the termination grace
-                                        period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
@@ -4714,10 +4344,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -4729,11 +4358,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -4752,25 +4379,24 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: Deprecated. TCPSocket is NOT
-                                            supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There
-                                            are no validation of this field and lifecycle
-                                            hooks will fail in runtime when tcp handler
-                                            is specified.
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for the backward compatibility. There are no validation of this field and
+                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4780,10 +4406,10 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -4791,33 +4417,30 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: 'Periodic probe of container liveness.
+                                  description: |-
+                                    Periodic probe of container liveness.
                                     Container will be restarted if the probe fails.
-                                    Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -4830,11 +4453,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -4844,8 +4468,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -4856,10 +4480,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -4877,35 +4500,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -4920,63 +4543,59 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: Name of the container specified as
-                                    a DNS_LABEL. Each container in a pod must have
-                                    a unique name (DNS_LABEL). Cannot be updated.
+                                  description: |-
+                                    Name of the container specified as a DNS_LABEL.
+                                    Each container in a pod must have a unique name (DNS_LABEL).
+                                    Cannot be updated.
                                   type: string
                                 ports:
-                                  description: List of ports to expose from the container.
-                                    Not specifying a port here DOES NOT prevent that
-                                    port from being exposed. Any port which is listening
-                                    on the default "0.0.0.0" address inside a container
-                                    will be accessible from the network. Modifying
-                                    this array with strategic merge patch may corrupt
-                                    the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  description: |-
+                                    List of ports to expose from the container. Not specifying a port here
+                                    DOES NOT prevent that port from being exposed. Any port which is
+                                    listening on the default "0.0.0.0" address inside a container will be
+                                    accessible from the network.
+                                    Modifying this array with strategic merge patch may corrupt the data.
+                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     Cannot be updated.
                                   items:
                                     description: ContainerPort represents a network
                                       port in a single container.
                                     properties:
                                       containerPort:
-                                        description: Number of port to expose on the
-                                          pod's IP address. This must be a valid port
-                                          number, 0 < x < 65536.
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
@@ -4984,24 +4603,24 @@ spec:
                                           port to.
                                         type: string
                                       hostPort:
-                                        description: Number of port to expose on the
-                                          host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
                                           Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: If specified, this must be an
-                                          IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: Protocol for port. Must be UDP,
-                                          TCP, or SCTP. Defaults to "TCP".
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -5012,34 +4631,30 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: 'Periodic probe of container service
-                                    readiness. Container will be removed from service
-                                    endpoints if the probe fails. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    Periodic probe of container service readiness.
+                                    Container will be removed from service endpoints if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -5052,11 +4667,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -5066,8 +4682,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -5078,10 +4694,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -5099,35 +4714,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -5142,38 +4757,33 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
@@ -5184,14 +4794,14 @@ spec:
                                       resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: 'Name of the resource to which
-                                          this resource resize policy applies. Supported
-                                          values: cpu, memory.'
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: Restart policy to apply when
-                                          specified resource is resized. If not specified,
-                                          it defaults to NotRequired.
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -5200,26 +4810,31 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: 'Compute Resources required by this
-                                    container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  description: |-
+                                    Compute Resources required by this container.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   properties:
                                     claims:
-                                      description: "Claims lists the names of resources,
-                                        defined in spec.resourceClaims, that are used
-                                        by this container. \n This is an alpha field
-                                        and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+
+                                        This is an alpha field and requires enabling the
+                                        DynamicResourceAllocation feature gate.
+
+
+                                        This field is immutable. It can only be set for containers.
                                       items:
                                         description: ResourceClaim references one
                                           entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: Name must match the name
-                                              of one entry in pod.spec.resourceClaims
-                                              of the Pod where this field is used.
-                                              It makes that resource available inside
-                                              a container.
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -5235,8 +4850,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -5245,61 +4861,52 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: 'RestartPolicy defines the restart
-                                    behavior of individual containers in a pod. This
-                                    field may only be set for init containers, and
-                                    the only allowed value is "Always". For non-init
-                                    containers or when this field is not specified,
-                                    the restart behavior is defined by the Pod''s
-                                    restart policy and the container type. Setting
-                                    the RestartPolicy as "Always" for the init container
-                                    will have the following effect: this init container
-                                    will be continually restarted on exit until all
-                                    regular containers have terminated. Once all regular
-                                    containers have completed, all init containers
-                                    with restartPolicy "Always" will be shut down.
-                                    This lifecycle differs from normal init containers
-                                    and is often referred to as a "sidecar" container.
-                                    Although this init container still starts in the
-                                    init container sequence, it does not wait for
-                                    the container to complete before proceeding to
-                                    the next init container. Instead, the next init
-                                    container starts immediately after this init container
-                                    is started, or after any startupProbe has successfully
-                                    completed.'
+                                  description: |-
+                                    RestartPolicy defines the restart behavior of individual containers in a pod.
+                                    This field may only be set for init containers, and the only allowed value is "Always".
+                                    For non-init containers or when this field is not specified,
+                                    the restart behavior is defined by the Pod's restart policy and the container type.
+                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                    this init container will be continually restarted on
+                                    exit until all regular containers have terminated. Once all regular
+                                    containers have completed, all init containers with restartPolicy "Always"
+                                    will be shut down. This lifecycle differs from normal init containers and
+                                    is often referred to as a "sidecar" container. Although this init
+                                    container still starts in the init container sequence, it does not wait
+                                    for the container to complete before proceeding to the next init
+                                    container. Instead, the next init container starts immediately after this
+                                    init container is started, or after any startupProbe has successfully
+                                    completed.
                                   type: string
                                 securityContext:
-                                  description: 'SecurityContext defines the security
-                                    options the container should be run with. If set,
-                                    the fields of SecurityContext override the equivalent
-                                    fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                  description: |-
+                                    SecurityContext defines the security options the container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
-                                        whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.'
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime. Note that this field cannot be set
-                                        when spec.os.name is windows.
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
                                           description: Added capabilities
@@ -5317,69 +4924,60 @@ spec:
                                           type: array
                                       type: object
                                     privileged:
-                                      description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false. Note that this field cannot be set
-                                        when spec.os.name is windows.
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled. Note that this field cannot
-                                        be set when spec.os.name is windows.
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default is DefaultProcMount which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only
-                                        root filesystem. Default is false. Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: The GID to run the entrypoint of
-                                        the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is windows.
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is windows.
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
                                           description: Level is SELinux level label
@@ -5399,112 +4997,93 @@ spec:
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: The seccomp options to use by this
-                                        container. If seccomp options are provided
-                                        at both the pod & container level, the container
-                                        options override the pod options. Note that
-                                        this field cannot be set when spec.os.name
-                                        is windows.
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: localhostProfile indicates
-                                            a profile defined in a file on the node
-                                            should be used. The profile must be preconfigured
-                                            on the node to work. Must be a descending
-                                            path, relative to the kubelet's configured
-                                            seccomp profile location. Must be set
-                                            if type is "Localhost". Must NOT be set
-                                            for any other type.
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: "type indicates which kind
-                                            of seccomp profile will be applied. Valid
-                                            options are: \n Localhost - a profile
-                                            defined in a file on the node should be
-                                            used. RuntimeDefault - the container runtime
-                                            default profile should be used. Unconfined
-                                            - no profile should be applied."
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. Note that this field cannot be
-                                        set when spec.os.name is linux.
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field.
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
                                           description: GMSACredentialSpecName is the
                                             name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: HostProcess determines if a
-                                            container should be run as a 'Host Process'
-                                            container. All of a Pod's containers must
-                                            have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess
-                                            containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then
-                                            HostNetwork must also be set to true.
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: The UserName in Windows to
-                                            run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: 'StartupProbe indicates that the Pod
-                                    has successfully initialized. If specified, no
-                                    other probes are executed until this completes
-                                    successfully. If this probe fails, the Pod will
-                                    be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters
-                                    at the beginning of a Pod''s lifecycle, when it
-                                    might take a long time to load data or warm a
-                                    cache, than during steady-state operation. This
-                                    cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  description: |-
+                                    StartupProbe indicates that the Pod has successfully initialized.
+                                    If specified, no other probes are executed until this completes successfully.
+                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                    This cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
                                       description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
@@ -5517,11 +5096,12 @@ spec:
                                           format: int32
                                           type: integer
                                         service:
-                                          description: "Service is the name of the
-                                            service to place in the gRPC HealthCheckRequest
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
                                             (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                            \n If this is not specified, the default
-                                            behavior is defined by gRPC."
+
+
+                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
@@ -5531,8 +5111,8 @@ spec:
                                         to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
                                             "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
@@ -5543,10 +5123,9 @@ spec:
                                               header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name.
-                                                  This will be canonicalized upon
-                                                  output, so case-variant names will
-                                                  be understood as the same header.
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
                                                 description: The header field value
@@ -5564,35 +5143,35 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
@@ -5607,87 +5186,76 @@ spec:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: Optional duration in seconds the
-                                        pod needs to terminate gracefully upon probe
-                                        failure. The grace period is the duration
-                                        in seconds after the processes running in
-                                        the pod are sent a termination signal and
-                                        the time when the processes are forcibly halted
-                                        with a kill signal. Set this value longer
-                                        than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds
-                                        will be used. Otherwise, this value overrides
-                                        the value provided by the pod spec. Value
-                                        must be non-negative integer. The value zero
-                                        indicates stop immediately via the kill signal
-                                        (no opportunity to shut down). This is a beta
-                                        field and requires enabling ProbeTerminationGracePeriod
-                                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                        is used if unset.
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: Whether the container runtime should
-                                    close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
                                   type: boolean
                                 terminationMessagePath:
-                                  description: 'Optional: Path at which the file to
-                                    which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: Whether this container should allocate
-                                    a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
                                   type: boolean
                                 volumeDevices:
                                   description: volumeDevices is the list of block
@@ -5711,46 +5279,45 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: Pod volumes to mount into the container's
-                                    filesystem. Cannot be updated.
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem.
+                                    Cannot be updated.
                                   items:
                                     description: VolumeMount describes a mounting
                                       of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at
-                                          which the volume should be mounted.  Must
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
                                           not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how
-                                          mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
                                         type: string
                                       name:
                                         description: This must match the Name of a
                                           Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write
-                                          otherwise (false or unspecified). Defaults
-                                          to false.
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which
-                                          the container's volume should be mounted.
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
                                           Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume
-                                          from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -5758,57 +5325,70 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           nodeName:
-                            description: NodeName is a request to schedule this pod
-                              onto a specific node. If it is non-empty, the scheduler
-                              simply schedules this pod onto that node, assuming that
-                              it fits resource requirements.
+                            description: |-
+                              NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                              the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                              requirements.
                             type: string
                           nodeSelector:
                             additionalProperties:
                               type: string
-                            description: 'NodeSelector is a selector which must be
-                              true for the pod to fit on a node. Selector which must
-                              match a node''s labels for the pod to be scheduled on
-                              that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                            description: |-
+                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                             type: object
                             x-kubernetes-map-type: atomic
                           os:
-                            description: "Specifies the OS of the containers in the
-                              pod. Some pod and container fields are restricted if
-                              this is set. \n If the OS field is set to linux, the
-                              following fields must be unset: -securityContext.windowsOptions
-                              \n If the OS field is set to windows, following fields
-                              must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                              - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
-                              - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
-                              - spec.securityContext.sysctls - spec.shareProcessNamespace
-                              - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
-                              - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
+                            description: |-
+                              Specifies the OS of the containers in the pod.
+                              Some pod and container fields are restricted if this is set.
+
+
+                              If the OS field is set to linux, the following fields must be unset:
+                              -securityContext.windowsOptions
+
+
+                              If the OS field is set to windows, following fields must be unset:
+                              - spec.hostPID
+                              - spec.hostIPC
+                              - spec.hostUsers
+                              - spec.securityContext.seLinuxOptions
+                              - spec.securityContext.seccompProfile
+                              - spec.securityContext.fsGroup
+                              - spec.securityContext.fsGroupChangePolicy
+                              - spec.securityContext.sysctls
+                              - spec.shareProcessNamespace
+                              - spec.securityContext.runAsUser
+                              - spec.securityContext.runAsGroup
+                              - spec.securityContext.supplementalGroups
+                              - spec.containers[*].securityContext.seLinuxOptions
                               - spec.containers[*].securityContext.seccompProfile
-                              - spec.containers[*].securityContext.capabilities -
-                              spec.containers[*].securityContext.readOnlyRootFilesystem
-                              - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
-                              - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                              - spec.containers[*].securityContext.runAsGroup"
+                              - spec.containers[*].securityContext.capabilities
+                              - spec.containers[*].securityContext.readOnlyRootFilesystem
+                              - spec.containers[*].securityContext.privileged
+                              - spec.containers[*].securityContext.allowPrivilegeEscalation
+                              - spec.containers[*].securityContext.procMount
+                              - spec.containers[*].securityContext.runAsUser
+                              - spec.containers[*].securityContext.runAsGroup
                             properties:
                               name:
-                                description: 'Name is the name of the operating system.
-                                  The currently supported values are linux and windows.
-                                  Additional value may be defined in future and can
-                                  be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                  Clients should expect to handle additional values
-                                  and treat unrecognized values in this field as os:
-                                  null'
+                                description: |-
+                                  Name is the name of the operating system. The currently supported values are linux and windows.
+                                  Additional value may be defined in future and can be one of:
+                                  https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                  Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                 type: string
                             required:
                             - name
@@ -5820,48 +5400,45 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Overhead represents the resource overhead
-                              associated with running a pod for a given RuntimeClass.
-                              This field will be autopopulated at admission time by
-                              the RuntimeClass admission controller. If the RuntimeClass
-                              admission controller is enabled, overhead must not be
-                              set in Pod create requests. The RuntimeClass admission
-                              controller will reject Pod create requests which have
-                              the overhead already set. If RuntimeClass is configured
-                              and selected in the PodSpec, Overhead will be set to
-                              the value defined in the corresponding RuntimeClass,
-                              otherwise it will remain unset and treated as zero.
-                              More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                            description: |-
+                              Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                              This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                              the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                              The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                              set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                              defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                              More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
                             type: object
                           preemptionPolicy:
-                            description: PreemptionPolicy is the Policy for preempting
-                              pods with lower priority. One of Never, PreemptLowerPriority.
+                            description: |-
+                              PreemptionPolicy is the Policy for preempting pods with lower priority.
+                              One of Never, PreemptLowerPriority.
                               Defaults to PreemptLowerPriority if unset.
                             type: string
                           priority:
-                            description: The priority value. Various system components
-                              use this field to find the priority of the pod. When
-                              Priority Admission Controller is enabled, it prevents
-                              users from setting this field. The admission controller
-                              populates this field from PriorityClassName. The higher
-                              the value, the higher the priority.
+                            description: |-
+                              The priority value. Various system components use this field to find the
+                              priority of the pod. When Priority Admission Controller is enabled, it
+                              prevents users from setting this field. The admission controller populates
+                              this field from PriorityClassName.
+                              The higher the value, the higher the priority.
                             format: int32
                             type: integer
                           priorityClassName:
-                            description: If specified, indicates the pod's priority.
-                              "system-node-critical" and "system-cluster-critical"
-                              are two special keywords which indicate the highest
-                              priorities with the former being the highest priority.
-                              Any other name must be defined by creating a PriorityClass
-                              object with that name. If not specified, the pod priority
-                              will be default or zero if there is no default.
+                            description: |-
+                              If specified, indicates the pod's priority. "system-node-critical" and
+                              "system-cluster-critical" are two special keywords which indicate the
+                              highest priorities with the former being the highest priority. Any other
+                              name must be defined by creating a PriorityClass object with that name.
+                              If not specified, the pod priority will be default or zero if there is no
+                              default.
                             type: string
                           readinessGates:
-                            description: 'If specified, all readiness gates will be
-                              evaluated for pod readiness. A pod is ready when all
-                              its containers are ready AND all conditions specified
-                              in the readiness gates have status equal to "True" More
-                              info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                            description: |-
+                              If specified, all readiness gates will be evaluated for pod readiness.
+                              A pod is ready when all its containers are ready AND
+                              all conditions specified in the readiness gates have status equal to "True"
+                              More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                             items:
                               description: PodReadinessGate contains the reference
                                 to a pod condition
@@ -5875,46 +5452,54 @@ spec:
                               type: object
                             type: array
                           resourceClaims:
-                            description: "ResourceClaims defines which ResourceClaims
-                              must be allocated and reserved before the Pod is allowed
-                              to start. The resources will be made available to those
-                              containers which consume them by name. \n This is an
-                              alpha field and requires enabling the DynamicResourceAllocation
-                              feature gate. \n This field is immutable."
+                            description: |-
+                              ResourceClaims defines which ResourceClaims must be allocated
+                              and reserved before the Pod is allowed to start. The resources
+                              will be made available to those containers which consume them
+                              by name.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable.
                             items:
-                              description: PodResourceClaim references exactly one
-                                ResourceClaim through a ClaimSource. It adds a name
-                                to it that uniquely identifies the ResourceClaim inside
-                                the Pod. Containers that need access to the ResourceClaim
-                                reference it with this name.
+                              description: |-
+                                PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                Containers that need access to the ResourceClaim reference it with this name.
                               properties:
                                 name:
-                                  description: Name uniquely identifies this resource
-                                    claim inside the pod. This must be a DNS_LABEL.
+                                  description: |-
+                                    Name uniquely identifies this resource claim inside the pod.
+                                    This must be a DNS_LABEL.
                                   type: string
                                 source:
                                   description: Source describes where to find the
                                     ResourceClaim.
                                   properties:
                                     resourceClaimName:
-                                      description: ResourceClaimName is the name of
-                                        a ResourceClaim object in the same namespace
-                                        as this pod.
+                                      description: |-
+                                        ResourceClaimName is the name of a ResourceClaim object in the same
+                                        namespace as this pod.
                                       type: string
                                     resourceClaimTemplateName:
-                                      description: "ResourceClaimTemplateName is the
-                                        name of a ResourceClaimTemplate object in
-                                        the same namespace as this pod. \n The template
-                                        will be used to create a new ResourceClaim,
-                                        which will be bound to this pod. When this
-                                        pod is deleted, the ResourceClaim will also
-                                        be deleted. The pod name and resource name,
-                                        along with a generated component, will be
-                                        used to form a unique name for the ResourceClaim,
-                                        which will be recorded in pod.status.resourceClaimStatuses.
-                                        \n This field is immutable and no changes
-                                        will be made to the corresponding ResourceClaim
-                                        by the control plane after creating the ResourceClaim."
+                                      description: |-
+                                        ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                        object in the same namespace as this pod.
+
+
+                                        The template will be used to create a new ResourceClaim, which will
+                                        be bound to this pod. When this pod is deleted, the ResourceClaim
+                                        will also be deleted. The pod name and resource name, along with a
+                                        generated component, will be used to form a unique name for the
+                                        ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+
+                                        This field is immutable and no changes will be made to the
+                                        corresponding ResourceClaim by the control plane after creating the
+                                        ResourceClaim.
                                       type: string
                                   type: object
                               required:
@@ -5925,41 +5510,44 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                           restartPolicy:
-                            description: 'Restart policy for all containers within
-                              the pod. One of Always, OnFailure, Never. In some contexts,
-                              only a subset of those values may be permitted. Default
-                              to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                            description: |-
+                              Restart policy for all containers within the pod.
+                              One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                              Default to Always.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                             type: string
                           runtimeClassName:
-                            description: 'RuntimeClassName refers to a RuntimeClass
-                              object in the node.k8s.io group, which should be used
-                              to run this pod.  If no RuntimeClass resource matches
-                              the named class, the pod will not be run. If unset or
-                              empty, the "legacy" RuntimeClass will be used, which
-                              is an implicit class with an empty definition that uses
-                              the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                            description: |-
+                              RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                              to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                              If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                              empty definition that uses the default runtime handler.
+                              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                             type: string
                           schedulerName:
-                            description: If specified, the pod will be dispatched
-                              by specified scheduler. If not specified, the pod will
-                              be dispatched by default scheduler.
+                            description: |-
+                              If specified, the pod will be dispatched by specified scheduler.
+                              If not specified, the pod will be dispatched by default scheduler.
                             type: string
                           schedulingGates:
-                            description: "SchedulingGates is an opaque list of values
-                              that if specified will block scheduling the pod. If
-                              schedulingGates is not empty, the pod will stay in the
-                              SchedulingGated state and the scheduler will not attempt
-                              to schedule the pod. \n SchedulingGates can only be
-                              set at pod creation time, and be removed only afterwards.
-                              \n This is a beta feature enabled by the PodSchedulingReadiness
-                              feature gate."
+                            description: |-
+                              SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                              If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                              scheduler will not attempt to schedule the pod.
+
+
+                              SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                              This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                             items:
                               description: PodSchedulingGate is associated to a Pod
                                 to guard its scheduling.
                               properties:
                                 name:
-                                  description: Name of the scheduling gate. Each scheduling
-                                    gate must have a unique name field.
+                                  description: |-
+                                    Name of the scheduling gate.
+                                    Each scheduling gate must have a unique name field.
                                   type: string
                               required:
                               - name
@@ -5969,75 +5557,73 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                           securityContext:
-                            description: 'SecurityContext holds pod-level security
-                              attributes and common container settings. Optional:
-                              Defaults to empty.  See type description for default
-                              values of each field.'
+                            description: |-
+                              SecurityContext holds pod-level security attributes and common container settings.
+                              Optional: Defaults to empty.  See type description for default values of each field.
                             properties:
                               fsGroup:
-                                description: "A special supplemental group that applies
-                                  to all containers in a pod. Some volume types allow
-                                  the Kubelet to change the ownership of that volume
-                                  to be owned by the pod: \n 1. The owning GID will
-                                  be the FSGroup 2. The setgid bit is set (new files
-                                  created in the volume will be owned by FSGroup)
-                                  3. The permission bits are OR'd with rw-rw---- \n
-                                  If unset, the Kubelet will not modify the ownership
-                                  and permissions of any volume. Note that this field
-                                  cannot be set when spec.os.name is windows."
+                                description: |-
+                                  A special supplemental group that applies to all containers in a pod.
+                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                  to be owned by the pod:
+
+
+                                  1. The owning GID will be the FSGroup
+                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                  3. The permission bits are OR'd with rw-rw----
+
+
+                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               fsGroupChangePolicy:
-                                description: 'fsGroupChangePolicy defines behavior
-                                  of changing ownership and permission of the volume
-                                  before being exposed inside Pod. This field will
-                                  only apply to volume types which support fsGroup
-                                  based ownership(and permissions). It will have no
-                                  effect on ephemeral volume types such as: secret,
-                                  configmaps and emptydir. Valid values are "OnRootMismatch"
-                                  and "Always". If not specified, "Always" is used.
-                                  Note that this field cannot be set when spec.os.name
-                                  is windows.'
+                                description: |-
+                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                  before being exposed inside Pod. This field will only apply to
+                                  volume types which support fsGroup based ownership(and permissions).
+                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                  and emptydir.
+                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               runAsGroup:
-                                description: The GID to run the entrypoint of the
-                                  container process. Uses runtime default if unset.
-                                  May also be set in SecurityContext.  If set in both
-                                  SecurityContext and PodSecurityContext, the value
-                                  specified in SecurityContext takes precedence for
-                                  that container. Note that this field cannot be set
-                                  when spec.os.name is windows.
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                  for that container.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: Indicates that the container must run
-                                  as a non-root user. If true, the Kubelet will validate
-                                  the image at runtime to ensure that it does not
-                                  run as UID 0 (root) and fail to start the container
-                                  if it does. If unset or false, no such validation
-                                  will be performed. May also be set in SecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
-                                description: The UID to run the entrypoint of the
-                                  container process. Defaults to user specified in
-                                  image metadata if unspecified. May also be set in
-                                  SecurityContext.  If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence for that container. Note that this
-                                  field cannot be set when spec.os.name is windows.
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                  for that container.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: The SELinux context to be applied to
-                                  all containers. If unspecified, the container runtime
-                                  will allocate a random SELinux context for each
-                                  container.  May also be set in SecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence
-                                  for that container. Note that this field cannot
-                                  be set when spec.os.name is windows.
+                                description: |-
+                                  The SELinux context to be applied to all containers.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in SecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence for that container.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   level:
                                     description: Level is SELinux level label that
@@ -6057,52 +5643,48 @@ spec:
                                     type: string
                                 type: object
                               seccompProfile:
-                                description: The seccomp options to use by the containers
-                                  in this pod. Note that this field cannot be set
-                                  when spec.os.name is windows.
+                                description: |-
+                                  The seccomp options to use by the containers in this pod.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
-                                    description: localhostProfile indicates a profile
-                                      defined in a file on the node should be used.
-                                      The profile must be preconfigured on the node
-                                      to work. Must be a descending path, relative
-                                      to the kubelet's configured seccomp profile
-                                      location. Must be set if type is "Localhost".
-                                      Must NOT be set for any other type.
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
                                     type: string
                                   type:
-                                    description: "type indicates which kind of seccomp
-                                      profile will be applied. Valid options are:
-                                      \n Localhost - a profile defined in a file on
-                                      the node should be used. RuntimeDefault - the
-                                      container runtime default profile should be
-                                      used. Unconfined - no profile should be applied."
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
                                     type: string
                                 required:
                                 - type
                                 type: object
                               supplementalGroups:
-                                description: A list of groups applied to the first
-                                  process run in each container, in addition to the
-                                  container's primary GID, the fsGroup (if specified),
-                                  and group memberships defined in the container image
-                                  for the uid of the container process. If unspecified,
-                                  no additional groups are added to any container.
-                                  Note that group memberships defined in the container
-                                  image for the uid of the container process are still
-                                  effective, even if they are not included in this
-                                  list. Note that this field cannot be set when spec.os.name
-                                  is windows.
+                                description: |-
+                                  A list of groups applied to the first process run in each container, in addition
+                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                  defined in the container image for the uid of the container process. If unspecified,
+                                  no additional groups are added to any container. Note that group memberships
+                                  defined in the container image for the uid of the container process are still effective,
+                                  even if they are not included in this list.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 items:
                                   format: int64
                                   type: integer
                                 type: array
                               sysctls:
-                                description: Sysctls hold a list of namespaced sysctls
-                                  used for the pod. Pods with unsupported sysctls
-                                  (by the container runtime) might fail to launch.
-                                  Note that this field cannot be set when spec.os.name
-                                  is windows.
+                                description: |-
+                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                  sysctls (by the container runtime) might fail to launch.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 items:
                                   description: Sysctl defines a kernel parameter to
                                     be set
@@ -6119,180 +5701,158 @@ spec:
                                   type: object
                                 type: array
                               windowsOptions:
-                                description: The Windows specific settings applied
-                                  to all containers. If unspecified, the options within
-                                  a container's SecurityContext will be used. If set
-                                  in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name
-                                  is linux.
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options within a container's SecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: GMSACredentialSpec is where the GMSA
-                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                      inlines the contents of the GMSA credential
-                                      spec named by the GMSACredentialSpecName field.
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
                                     type: string
                                   gmsaCredentialSpecName:
                                     description: GMSACredentialSpecName is the name
                                       of the GMSA credential spec to use.
                                     type: string
                                   hostProcess:
-                                    description: HostProcess determines if a container
-                                      should be run as a 'Host Process' container.
-                                      All of a Pod's containers must have the same
-                                      effective HostProcess value (it is not allowed
-                                      to have a mix of HostProcess containers and
-                                      non-HostProcess containers). In addition, if
-                                      HostProcess is true then HostNetwork must also
-                                      be set to true.
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
                                     type: boolean
                                   runAsUserName:
-                                    description: The UserName in Windows to run the
-                                      entrypoint of the container process. Defaults
-                                      to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence.
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: string
                                 type: object
                             type: object
                           serviceAccount:
-                            description: 'DeprecatedServiceAccount is a depreciated
-                              alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                              instead.'
+                            description: |-
+                              DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                              Deprecated: Use serviceAccountName instead.
                             type: string
                           serviceAccountName:
-                            description: 'ServiceAccountName is the name of the ServiceAccount
-                              to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                            description: |-
+                              ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                             type: string
                           setHostnameAsFQDN:
-                            description: If true the pod's hostname will be configured
-                              as the pod's FQDN, rather than the leaf name (the default).
-                              In Linux containers, this means setting the FQDN in
-                              the hostname field of the kernel (the nodename field
-                              of struct utsname). In Windows containers, this means
-                              setting the registry value of hostname for the registry
-                              key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                              to FQDN. If a pod does not have FQDN, this has no effect.
+                            description: |-
+                              If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                              In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                              In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                              If a pod does not have FQDN, this has no effect.
                               Default to false.
                             type: boolean
                           shareProcessNamespace:
-                            description: 'Share a single process namespace between
-                              all of the containers in a pod. When this is set containers
-                              will be able to view and signal processes from other
-                              containers in the same pod, and the first process in
-                              each container will not be assigned PID 1. HostPID and
-                              ShareProcessNamespace cannot both be set. Optional:
-                              Default to false.'
+                            description: |-
+                              Share a single process namespace between all of the containers in a pod.
+                              When this is set containers will be able to view and signal processes from other containers
+                              in the same pod, and the first process in each container will not be assigned PID 1.
+                              HostPID and ShareProcessNamespace cannot both be set.
+                              Optional: Default to false.
                             type: boolean
                           subdomain:
-                            description: If specified, the fully qualified Pod hostname
-                              will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                              domain>". If not specified, the pod will not have a
-                              domainname at all.
+                            description: |-
+                              If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                              If not specified, the pod will not have a domainname at all.
                             type: string
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully. May be decreased in delete
-                              request. Value must be non-negative integer. The value
-                              zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). If this value is nil,
-                              the default grace period will be used instead. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. Defaults to 30 seconds.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              If this value is nil, the default grace period will be used instead.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              Defaults to 30 seconds.
                             format: int64
                             type: integer
                           tolerations:
                             description: If specified, the pod's tolerations.
                             items:
-                              description: The pod this Toleration is attached to
-                                tolerates any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
                               properties:
                                 effect:
-                                  description: Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                   type: string
                                 key:
-                                  description: Key is the taint key that the toleration
-                                    applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists;
-                                    this combination means to match all values and
-                                    all keys.
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                   type: string
                                 operator:
-                                  description: Operator represents a key's relationship
-                                    to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
                                   type: string
                                 tolerationSeconds:
-                                  description: TolerationSeconds represents the period
-                                    of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
                                   format: int64
                                   type: integer
                                 value:
-                                  description: Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
                                   type: string
                               type: object
                             type: array
                           topologySpreadConstraints:
-                            description: TopologySpreadConstraints describes how a
-                              group of pods ought to spread across topology domains.
-                              Scheduler will schedule pods in a way which abides by
-                              the constraints. All topologySpreadConstraints are ANDed.
+                            description: |-
+                              TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                              domains. Scheduler will schedule pods in a way which abides by the constraints.
+                              All topologySpreadConstraints are ANDed.
                             items:
                               description: TopologySpreadConstraint specifies how
                                 to spread matching pods among the given topology.
                               properties:
                                 labelSelector:
-                                  description: LabelSelector is used to find matching
-                                    pods. Pods that match this label selector are
-                                    counted to determine the number of pods in their
-                                    corresponding topology domain.
+                                  description: |-
+                                    LabelSelector is used to find matching pods.
+                                    Pods that match this label selector are counted to determine the number of pods
+                                    in their corresponding topology domain.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
                                         selector requirements. The requirements are
                                         ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that
                                               the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
                                               merge patch.
                                             items:
                                               type: string
@@ -6305,147 +5865,134 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: "MatchLabelKeys is a set of pod label
-                                    keys to select the pods over which spreading will
-                                    be calculated. The keys are used to lookup values
-                                    from the incoming pod labels, those key-value
-                                    labels are ANDed with labelSelector to select
-                                    the group of existing pods over which spreading
-                                    will be calculated for the incoming pod. The same
-                                    key is forbidden to exist in both MatchLabelKeys
-                                    and LabelSelector. MatchLabelKeys cannot be set
-                                    when LabelSelector isn't set. Keys that don't
-                                    exist in the incoming pod labels will be ignored.
-                                    A null or empty list means only match against
-                                    labelSelector. \n This is a beta field and requires
-                                    the MatchLabelKeysInPodTopologySpread feature
-                                    gate to be enabled (enabled by default)."
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select the pods over which
+                                    spreading will be calculated. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are ANDed with labelSelector
+                                    to select the group of existing pods over which spreading will be calculated
+                                    for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    Keys that don't exist in the incoming pod labels will
+                                    be ignored. A null or empty list means only match against labelSelector.
+
+
+                                    This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 maxSkew:
-                                  description: 'MaxSkew describes the degree to which
-                                    pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                    it is the maximum permitted difference between
-                                    the number of matching pods in the target topology
-                                    and the global minimum. The global minimum is
-                                    the minimum number of matching pods in an eligible
-                                    domain or zero if the number of eligible domains
-                                    is less than MinDomains. For example, in a 3-zone
-                                    cluster, MaxSkew is set to 1, and pods with the
-                                    same labelSelector spread as 2/2/1: In this case,
-                                    the global minimum is 1. | zone1 | zone2 | zone3
-                                    | |  P P  |  P P  |   P   | - if MaxSkew is 1,
-                                    incoming pod can only be scheduled to zone3 to
-                                    become 2/2/2; scheduling it onto zone1(zone2)
-                                    would make the ActualSkew(3-1) on zone1(zone2)
-                                    violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                    pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                    it is used to give higher precedence to topologies
-                                    that satisfy it. It''s a required field. Default
-                                    value is 1 and 0 is not allowed.'
+                                  description: |-
+                                    MaxSkew describes the degree to which pods may be unevenly distributed.
+                                    When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                    between the number of matching pods in the target topology and the global minimum.
+                                    The global minimum is the minimum number of matching pods in an eligible domain
+                                    or zero if the number of eligible domains is less than MinDomains.
+                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                    labelSelector spread as 2/2/1:
+                                    In this case, the global minimum is 1.
+                                    | zone1 | zone2 | zone3 |
+                                    |  P P  |  P P  |   P   |
+                                    - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                    scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                    violate MaxSkew(1).
+                                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                    to topologies that satisfy it.
+                                    It's a required field. Default value is 1 and 0 is not allowed.
                                   format: int32
                                   type: integer
                                 minDomains:
-                                  description: "MinDomains indicates a minimum number
-                                    of eligible domains. When the number of eligible
-                                    domains with matching topology keys is less than
-                                    minDomains, Pod Topology Spread treats \"global
-                                    minimum\" as 0, and then the calculation of Skew
-                                    is performed. And when the number of eligible
-                                    domains with matching topology keys equals or
-                                    greater than minDomains, this value has no effect
-                                    on scheduling. As a result, when the number of
-                                    eligible domains is less than minDomains, scheduler
-                                    won't schedule more than maxSkew Pods to those
-                                    domains. If value is nil, the constraint behaves
-                                    as if MinDomains is equal to 1. Valid values are
-                                    integers greater than 0. When value is not nil,
-                                    WhenUnsatisfiable must be DoNotSchedule. \n For
-                                    example, in a 3-zone cluster, MaxSkew is set to
-                                    2, MinDomains is set to 5 and pods with the same
-                                    labelSelector spread as 2/2/2: | zone1 | zone2
-                                    | zone3 | |  P P  |  P P  |  P P  | The number
-                                    of domains is less than 5(MinDomains), so \"global
-                                    minimum\" is treated as 0. In this situation,
-                                    new pod with the same labelSelector cannot be
-                                    scheduled, because computed skew will be 3(3 -
-                                    0) if new Pod is scheduled to any of the three
-                                    zones, it will violate MaxSkew. \n This is a beta
-                                    field and requires the MinDomainsInPodTopologySpread
-                                    feature gate to be enabled (enabled by default)."
+                                  description: |-
+                                    MinDomains indicates a minimum number of eligible domains.
+                                    When the number of eligible domains with matching topology keys is less than minDomains,
+                                    Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                    And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                    this value has no effect on scheduling.
+                                    As a result, when the number of eligible domains is less than minDomains,
+                                    scheduler won't schedule more than maxSkew Pods to those domains.
+                                    If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                    Valid values are integers greater than 0.
+                                    When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                    labelSelector spread as 2/2/2:
+                                    | zone1 | zone2 | zone3 |
+                                    |  P P  |  P P  |  P P  |
+                                    The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                    In this situation, new pod with the same labelSelector cannot be scheduled,
+                                    because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                    it will violate MaxSkew.
+
+
+                                    This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                                   format: int32
                                   type: integer
                                 nodeAffinityPolicy:
-                                  description: "NodeAffinityPolicy indicates how we
-                                    will treat Pod's nodeAffinity/nodeSelector when
-                                    calculating pod topology spread skew. Options
-                                    are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                                    are included in the calculations. - Ignore: nodeAffinity/nodeSelector
-                                    are ignored. All nodes are included in the calculations.
-                                    \n If this value is nil, the behavior is equivalent
-                                    to the Honor policy. This is a beta-level feature
-                                    default enabled by the NodeInclusionPolicyInPodTopologySpread
-                                    feature flag."
+                                  description: |-
+                                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                    when calculating pod topology spread skew. Options are:
+                                    - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                    - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                    If this value is nil, the behavior is equivalent to the Honor policy.
+                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 nodeTaintsPolicy:
-                                  description: "NodeTaintsPolicy indicates how we
-                                    will treat node taints when calculating pod topology
-                                    spread skew. Options are: - Honor: nodes without
-                                    taints, along with tainted nodes for which the
-                                    incoming pod has a toleration, are included. -
-                                    Ignore: node taints are ignored. All nodes are
-                                    included. \n If this value is nil, the behavior
-                                    is equivalent to the Ignore policy. This is a
-                                    beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread
-                                    feature flag."
+                                  description: |-
+                                    NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                    pod topology spread skew. Options are:
+                                    - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                    has a toleration, are included.
+                                    - Ignore: node taints are ignored. All nodes are included.
+
+
+                                    If this value is nil, the behavior is equivalent to the Ignore policy.
+                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 topologyKey:
-                                  description: TopologyKey is the key of node labels.
-                                    Nodes that have a label with this key and identical
-                                    values are considered to be in the same topology.
-                                    We consider each <key, value> as a "bucket", and
-                                    try to put balanced number of pods into each bucket.
-                                    We define a domain as a particular instance of
-                                    a topology. Also, we define an eligible domain
-                                    as a domain whose nodes meet the requirements
-                                    of nodeAffinityPolicy and nodeTaintsPolicy. e.g.
-                                    If TopologyKey is "kubernetes.io/hostname", each
-                                    Node is a domain of that topology. And, if TopologyKey
-                                    is "topology.kubernetes.io/zone", each zone is
-                                    a domain of that topology. It's a required field.
+                                  description: |-
+                                    TopologyKey is the key of node labels. Nodes that have a label with this key
+                                    and identical values are considered to be in the same topology.
+                                    We consider each <key, value> as a "bucket", and try to put balanced number
+                                    of pods into each bucket.
+                                    We define a domain as a particular instance of a topology.
+                                    Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                    nodeAffinityPolicy and nodeTaintsPolicy.
+                                    e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                    It's a required field.
                                   type: string
                                 whenUnsatisfiable:
-                                  description: 'WhenUnsatisfiable indicates how to
-                                    deal with a pod if it doesn''t satisfy the spread
-                                    constraint. - DoNotSchedule (default) tells the
-                                    scheduler not to schedule it. - ScheduleAnyway
-                                    tells the scheduler to schedule the pod in any
-                                    location, but giving higher precedence to topologies
-                                    that would help reduce the skew. A constraint
-                                    is considered "Unsatisfiable" for an incoming
-                                    pod if and only if every possible node assignment
-                                    for that pod would violate "MaxSkew" on some topology.
-                                    For example, in a 3-zone cluster, MaxSkew is set
-                                    to 1, and pods with the same labelSelector spread
-                                    as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                                    If WhenUnsatisfiable is set to DoNotSchedule,
-                                    incoming pod can only be scheduled to zone2(zone3)
-                                    to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
-                                    satisfies MaxSkew(1). In other words, the cluster
-                                    can still be imbalanced, but scheduler won''t
-                                    make it *more* imbalanced. It''s a required field.'
+                                  description: |-
+                                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                    the spread constraint.
+                                    - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                    - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                      but giving higher precedence to topologies that would help reduce the
+                                      skew.
+                                    A constraint is considered "Unsatisfiable" for an incoming pod
+                                    if and only if every possible node assignment for that pod would violate
+                                    "MaxSkew" on some topology.
+                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                    labelSelector spread as 3/1/1:
+                                    | zone1 | zone2 | zone3 |
+                                    | P P P |   P   |   P   |
+                                    If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                    to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                    MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                    won't make it *more* imbalanced.
+                                    It's a required field.
                                   type: string
                               required:
                               - maxSkew
@@ -6458,47 +6005,44 @@ spec:
                             - whenUnsatisfiable
                             x-kubernetes-list-type: map
                           volumes:
-                            description: 'List of volumes that can be mounted by containers
-                              belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                            description: |-
+                              List of volumes that can be mounted by containers belonging to the pod.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes
                             items:
                               description: Volume represents a named volume in a pod
                                 that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: 'awsElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: |-
+                                    awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
+                                      description: |-
+                                        partition is the partition in the volume that you want to mount.
+                                        If omitted, the default is to mount by volume name.
+                                        Examples: For volume /dev/sda1, you specify the partition as "1".
+                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly value true will force
-                                        the readOnly setting in VolumeMounts. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      description: |-
+                                        readOnly value true will force the readOnly setting in VolumeMounts.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       type: boolean
                                     volumeID:
-                                      description: 'volumeID is unique ID of the persistent
-                                        disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      description: |-
+                                        volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       type: string
                                   required:
                                   - volumeID
@@ -6520,11 +6064,10 @@ spec:
                                         in the blob storage
                                       type: string
                                     fsType:
-                                      description: fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
+                                      description: |-
+                                        fsType is Filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     kind:
                                       description: 'kind expected values are Shared:
@@ -6534,9 +6077,9 @@ spec:
                                         set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
+                                      description: |-
+                                        readOnly Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
@@ -6548,9 +6091,9 @@ spec:
                                     pod.
                                   properties:
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretName:
                                       description: secretName is the  name of secret
@@ -6569,9 +6112,9 @@ spec:
                                     the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'monitors is Required: Monitors
-                                        is a collection of Ceph monitors More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      description: |-
+                                        monitors is Required: Monitors is a collection of Ceph monitors
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       items:
                                         type: string
                                       type: array
@@ -6581,70 +6124,72 @@ spec:
                                         default is /'
                                       type: string
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      description: |-
+                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: boolean
                                     secretFile:
-                                      description: 'secretFile is Optional: SecretFile
-                                        is the path to key ring for User, default
-                                        is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      description: |-
+                                        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: string
                                     secretRef:
-                                      description: 'secretRef is Optional: SecretRef
-                                        is reference to the authentication secret
-                                        for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      description: |-
+                                        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is optional: User is the
-                                        rados user name, default is admin More info:
-                                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                      description: |-
+                                        user is optional: User is the rados user name, default is admin
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: 'cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: |-
+                                    cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: string
                                     readOnly:
-                                      description: 'readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is optional: points
-                                        to a secret object containing parameters used
-                                        to connect to OpenStack.'
+                                      description: |-
+                                        secretRef is optional: points to a secret object containing parameters used to connect
+                                        to OpenStack.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: 'volumeID used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      description: |-
+                                        volumeID used to identify the volume in cinder.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: string
                                   required:
                                   - volumeID
@@ -6654,31 +6199,25 @@ spec:
                                     should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
+                                      description: |-
+                                        defaultMode is optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -6687,26 +6226,21 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -6714,10 +6248,10 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap
@@ -6731,47 +6265,43 @@ spec:
                                     CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
+                                      description: |-
+                                        driver is the name of the CSI driver that handles this volume.
+                                        Consult with your admin for the correct name as registered in the cluster.
                                       type: string
                                     fsType:
-                                      description: fsType to mount. Ex. "ext4", "xfs",
-                                        "ntfs". If not provided, the empty value is
-                                        passed to the associated CSI driver which
-                                        will determine the default filesystem to apply.
+                                      description: |-
+                                        fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                        If not provided, the empty value is passed to the associated CSI driver
+                                        which will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: nodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
+                                      description: |-
+                                        nodePublishSecretRef is a reference to the secret object containing
+                                        sensitive information to pass to the CSI driver to complete the CSI
+                                        NodePublishVolume and NodeUnpublishVolume calls.
+                                        This field is optional, and  may be empty if no secret is required. If the
+                                        secret object contains more than one secret, all secret references are passed.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: readOnly specifies a read-only
-                                        configuration for the volume. Defaults to
-                                        false (read/write).
+                                      description: |-
+                                        readOnly specifies a read-only configuration for the volume.
+                                        Defaults to false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: volumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
+                                      description: |-
+                                        volumeAttributes stores driver-specific properties that are passed to the CSI
+                                        driver. Consult your driver's documentation for supported values.
                                       type: object
                                   required:
                                   - driver
@@ -6781,18 +6311,15 @@ spec:
                                     about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a Optional:
-                                        mode bits used to set permissions on created
-                                        files by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
+                                      description: |-
+                                        Optional: mode bits to use on created files by default. Must be a
+                                        Optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
@@ -6822,18 +6349,13 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on this file, must
-                                              be an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. If not specified, the
-                                              volume defaultMode will be used. This
-                                              might be in conflict with other options
-                                              that affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
@@ -6845,11 +6367,9 @@ spec:
                                               must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -6878,128 +6398,125 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: 'emptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: |-
+                                    emptyDir represents a temporary directory that shares a pod's lifetime.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   properties:
                                     medium:
-                                      description: 'medium represents what type of
-                                        storage medium should back this directory.
-                                        The default is "" which means to use the node''s
-                                        default medium. Must be an empty string (default)
-                                        or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: |-
+                                        medium represents what type of storage medium should back this directory.
+                                        The default is "" which means to use the node's default medium.
+                                        Must be an empty string (default) or Memory.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: 'sizeLimit is the total amount
-                                        of local storage required for this EmptyDir
-                                        volume. The size limit is also applicable
-                                        for memory medium. The maximum usage on memory
-                                        medium EmptyDir would be the minimum value
-                                        between the SizeLimit specified here and the
-                                        sum of memory limits of all containers in
-                                        a pod. The default is nil which means that
-                                        the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: |-
+                                        sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                        The size limit is also applicable for memory medium.
+                                        The maximum usage on memory medium EmptyDir would be the minimum value between
+                                        the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                        The default is nil which means that the limit is undefined.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: "ephemeral represents a volume that
-                                    is handled by a cluster storage driver. The volume's
-                                    lifecycle is tied to the pod that defines it -
-                                    it will be created before the pod starts, and
-                                    deleted when the pod is removed. \n Use this if:
+                                  description: |-
+                                    ephemeral represents a volume that is handled by a cluster storage driver.
+                                    The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                    and deleted when the pod is removed.
+
+
+                                    Use this if:
                                     a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from
-                                    snapshot or capacity tracking are needed, c) the
-                                    storage driver is specified through a storage
-                                    class, and d) the storage driver supports dynamic
-                                    volume provisioning through a PersistentVolumeClaim
-                                    (see EphemeralVolumeSource for more information
-                                    on the connection between this volume type and
-                                    PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                    or one of the vendor-specific APIs for volumes
-                                    that persist for longer than the lifecycle of
-                                    an individual pod. \n Use CSI for light-weight
-                                    local ephemeral volumes if the CSI driver is meant
-                                    to be used that way - see the documentation of
-                                    the driver for more information. \n A pod can
-                                    use both types of ephemeral volumes and persistent
-                                    volumes at the same time."
+                                    b) features of normal volumes like restoring from snapshot or capacity
+                                       tracking are needed,
+                                    c) the storage driver is specified through a storage class, and
+                                    d) the storage driver supports dynamic volume provisioning through
+                                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                       information on the connection between this volume type
+                                       and PersistentVolumeClaim).
+
+
+                                    Use PersistentVolumeClaim or one of the vendor-specific
+                                    APIs for volumes that persist for longer than the lifecycle
+                                    of an individual pod.
+
+
+                                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                    be used that way - see the documentation of the driver for
+                                    more information.
+
+
+                                    A pod can use both types of ephemeral volumes and
+                                    persistent volumes at the same time.
                                   properties:
                                     volumeClaimTemplate:
-                                      description: "Will be used to create a stand-alone
-                                        PVC to provision the volume. The pod in which
-                                        this EphemeralVolumeSource is embedded will
-                                        be the owner of the PVC, i.e. the PVC will
-                                        be deleted together with the pod.  The name
-                                        of the PVC will be `<pod name>-<volume name>`
-                                        where `<volume name>` is the name from the
-                                        `PodSpec.Volumes` array entry. Pod validation
-                                        will reject the pod if the concatenated name
+                                      description: |-
+                                        Will be used to create a stand-alone PVC to provision the volume.
+                                        The pod in which this EphemeralVolumeSource is embedded will be the
+                                        owner of the PVC, i.e. the PVC will be deleted together with the
+                                        pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                        `<volume name>` is the name from the `PodSpec.Volumes` array
+                                        entry. Pod validation will reject the pod if the concatenated name
                                         is not valid for a PVC (for example, too long).
-                                        \n An existing PVC with that name that is
-                                        not owned by the pod will *not* be used for
-                                        the pod to avoid using an unrelated volume
-                                        by mistake. Starting the pod is then blocked
-                                        until the unrelated PVC is removed. If such
-                                        a pre-created PVC is meant to be used by the
-                                        pod, the PVC has to updated with an owner
-                                        reference to the pod once the pod exists.
-                                        Normally this should not be necessary, but
-                                        it may be useful when manually reconstructing
-                                        a broken cluster. \n This field is read-only
-                                        and no changes will be made by Kubernetes
-                                        to the PVC after it has been created. \n Required,
-                                        must not be nil."
+
+
+                                        An existing PVC with that name that is not owned by the pod
+                                        will *not* be used for the pod to avoid using an unrelated
+                                        volume by mistake. Starting the pod is then blocked until
+                                        the unrelated PVC is removed. If such a pre-created PVC is
+                                        meant to be used by the pod, the PVC has to updated with an
+                                        owner reference to the pod once the pod exists. Normally
+                                        this should not be necessary, but it may be useful when
+                                        manually reconstructing a broken cluster.
+
+
+                                        This field is read-only and no changes will be made by Kubernetes
+                                        to the PVC after it has been created.
+
+
+                                        Required, must not be nil.
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations
-                                            that will be copied into the PVC when
-                                            creating it. No other fields are allowed
-                                            and will be rejected during validation.
+                                          description: |-
+                                            May contain labels and annotations that will be copied into the PVC
+                                            when creating it. No other fields are allowed and will be rejected during
+                                            validation.
                                           type: object
                                         spec:
-                                          description: The specification for the PersistentVolumeClaim.
-                                            The entire content is copied unchanged
-                                            into the PVC that gets created from this
+                                          description: |-
+                                            The specification for the PersistentVolumeClaim. The entire content is
+                                            copied unchanged into the PVC that gets created from this
                                             template. The same fields as in a PersistentVolumeClaim
                                             are also valid here.
                                           properties:
                                             accessModes:
-                                              description: 'accessModes contains the
-                                                desired access modes the volume should
-                                                have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                              description: |-
+                                                accessModes contains the desired access modes the volume should have.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'dataSource field can be
-                                                used to specify either: * An existing
-                                                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              description: |-
+                                                dataSource field can be used to specify either:
+                                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                 * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external
-                                                controller can support the specified
-                                                data source, it will create a new
-                                                volume based on the contents of the
-                                                specified data source. When the AnyVolumeDataSource
-                                                feature gate is enabled, dataSource
-                                                contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be
-                                                copied to dataSource when dataSourceRef.namespace
-                                                is not specified. If the namespace
-                                                is specified, then dataSourceRef will
-                                                not be copied to dataSource.'
+                                                If the provisioner or an external controller can support the specified data source,
+                                                it will create a new volume based on the contents of the specified data source.
+                                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
+                                                  description: |-
+                                                    APIGroup is the group for the resource being referenced.
+                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                    For any other third-party types, APIGroup is required.
                                                   type: string
                                                 kind:
                                                   description: Kind is the type of
@@ -7015,57 +6532,36 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: 'dataSourceRef specifies
-                                                the object from which to populate
-                                                the volume with data, if a non-empty
-                                                volume is desired. This may be any
-                                                object from a non-empty API group
-                                                (non core object) or a PersistentVolumeClaim
-                                                object. When this field is specified,
-                                                volume binding will only succeed if
-                                                the type of the specified object matches
-                                                some installed volume populator or
-                                                dynamic provisioner. This field will
-                                                replace the functionality of the dataSource
-                                                field and as such if both fields are
-                                                non-empty, they must have the same
-                                                value. For backwards compatibility,
-                                                when namespace isn''t specified in
-                                                dataSourceRef, both fields (dataSource
-                                                and dataSourceRef) will be set to
-                                                the same value automatically if one
-                                                of them is empty and the other is
-                                                non-empty. When namespace is specified
-                                                in dataSourceRef, dataSource isn''t
-                                                set to the same value and must be
-                                                empty. There are three important differences
-                                                between dataSource and dataSourceRef:
-                                                * While dataSource only allows two
-                                                specific types of objects, dataSourceRef
-                                                allows any non-core object, as well
-                                                as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed
-                                                values (dropping them), dataSourceRef
-                                                preserves all values, and generates
-                                                an error if a disallowed value is
-                                                specified. * While dataSource only
-                                                allows local objects, dataSourceRef
-                                                allows objects in any namespaces.
-                                                (Beta) Using this field requires the
-                                                AnyVolumeDataSource feature gate to
-                                                be enabled. (Alpha) Using the namespace
-                                                field of dataSourceRef requires the
-                                                CrossNamespaceVolumeDataSource feature
-                                                gate to be enabled.'
+                                              description: |-
+                                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                volume is desired. This may be any object from a non-empty API group (non
+                                                core object) or a PersistentVolumeClaim object.
+                                                When this field is specified, volume binding will only succeed if the type of
+                                                the specified object matches some installed volume populator or dynamic
+                                                provisioner.
+                                                This field will replace the functionality of the dataSource field and as such
+                                                if both fields are non-empty, they must have the same value. For backwards
+                                                compatibility, when namespace isn't specified in dataSourceRef,
+                                                both fields (dataSource and dataSourceRef) will be set to the same
+                                                value automatically if one of them is empty and the other is non-empty.
+                                                When namespace is specified in dataSourceRef,
+                                                dataSource isn't set to the same value and must be empty.
+                                                There are three important differences between dataSource and dataSourceRef:
+                                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                  preserves all values, and generates an error if a disallowed value is
+                                                  specified.
+                                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                                  in any namespaces.
+                                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group
-                                                    for the resource being referenced.
-                                                    If APIGroup is not specified,
-                                                    the specified Kind must be in
-                                                    the core API group. For any other
-                                                    third-party types, APIGroup is
-                                                    required.
+                                                  description: |-
+                                                    APIGroup is the group for the resource being referenced.
+                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                    For any other third-party types, APIGroup is required.
                                                   type: string
                                                 kind:
                                                   description: Kind is the type of
@@ -7076,53 +6572,43 @@ spec:
                                                     resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: Namespace is the namespace
-                                                    of resource being referenced Note
-                                                    that when a namespace is specified,
-                                                    a gateway.networking.k8s.io/ReferenceGrant
-                                                    object is required in the referent
-                                                    namespace to allow that namespace's
-                                                    owner to accept the reference.
-                                                    See the ReferenceGrant documentation
-                                                    for details. (Alpha) This field
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.
+                                                  description: |-
+                                                    Namespace is the namespace of resource being referenced
+                                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'resources represents the
-                                                minimum resources the volume should
-                                                have. If RecoverVolumeExpansionFailure
-                                                feature is enabled users are allowed
-                                                to specify resource requirements that
-                                                are lower than previous value but
-                                                must still be higher than capacity
-                                                recorded in the status field of the
-                                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                              description: |-
+                                                resources represents the minimum resources the volume should have.
+                                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                that are lower than previous value but must still be higher than capacity recorded in the
+                                                status field of the claim.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                               properties:
                                                 claims:
-                                                  description: "Claims lists the names
-                                                    of resources, defined in spec.resourceClaims,
+                                                  description: |-
+                                                    Claims lists the names of resources, defined in spec.resourceClaims,
                                                     that are used by this container.
-                                                    \n This is an alpha field and
-                                                    requires enabling the DynamicResourceAllocation
-                                                    feature gate. \n This field is
-                                                    immutable. It can only be set
-                                                    for containers."
+
+
+                                                    This is an alpha field and requires enabling the
+                                                    DynamicResourceAllocation feature gate.
+
+
+                                                    This field is immutable. It can only be set for containers.
                                                   items:
                                                     description: ResourceClaim references
                                                       one entry in PodSpec.ResourceClaims.
                                                     properties:
                                                       name:
-                                                        description: Name must match
-                                                          the name of one entry in
-                                                          pod.spec.resourceClaims
-                                                          of the Pod where this field
-                                                          is used. It makes that resource
-                                                          available inside a container.
+                                                        description: |-
+                                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                                          the Pod where this field is used. It makes that resource available
+                                                          inside a container.
                                                         type: string
                                                     required:
                                                     - name
@@ -7138,9 +6624,9 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the
-                                                    maximum amount of compute resources
-                                                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  description: |-
+                                                    Limits describes the maximum amount of compute resources allowed.
+                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -7149,15 +6635,11 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Requests describes
-                                                    the minimum amount of compute
-                                                    resources required. If Requests
-                                                    is omitted for a container, it
-                                                    defaults to Limits if that is
-                                                    explicitly specified, otherwise
-                                                    to an implementation-defined value.
-                                                    Requests cannot exceed Limits.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  description: |-
+                                                    Requests describes the minimum amount of compute resources required.
+                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                   type: object
                                               type: object
                                             selector:
@@ -7169,11 +6651,9 @@ spec:
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -7181,23 +6661,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -7209,28 +6682,22 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: 'storageClassName is the
-                                                name of the StorageClass required
-                                                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                              description: |-
+                                                storageClassName is the name of the StorageClass required by the claim.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what
-                                                type of volume is required by the
-                                                claim. Value of Filesystem is implied
-                                                when not included in claim spec.
+                                              description: |-
+                                                volumeMode defines what type of volume is required by the claim.
+                                                Value of Filesystem is implied when not included in claim spec.
                                               type: string
                                             volumeName:
                                               description: volumeName is the binding
@@ -7248,12 +6715,11 @@ spec:
                                     then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        to mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. TODO: how do we prevent errors
-                                        in the filesystem from compromising the machine'
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     lun:
                                       description: 'lun is Optional: FC target lun
@@ -7261,9 +6727,9 @@ spec:
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: 'readOnly is Optional: Defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
+                                      description: |-
+                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     targetWWNs:
                                       description: 'targetWWNs is Optional: FC target
@@ -7272,29 +6738,27 @@ spec:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'wwids Optional: FC volume world
-                                        wide identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
+                                      description: |-
+                                        wwids Optional: FC volume world wide identifiers (wwids)
+                                        Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: flexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
+                                  description: |-
+                                    flexVolume represents a generic volume resource that is
+                                    provisioned/attached using an exec based plugin.
                                   properties:
                                     driver:
                                       description: driver is the name of the driver
                                         to use for this volume.
                                       type: string
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". The default filesystem depends
-                                        on FlexVolume script.
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
@@ -7303,24 +6767,23 @@ spec:
                                         holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: 'readOnly is Optional: defaults
-                                        to false (read/write). ReadOnly here will
-                                        force the ReadOnly setting in VolumeMounts.'
+                                      description: |-
+                                        readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is Optional: secretRef
-                                        is reference to the secret object containing
-                                        sensitive information to pass to the plugin
-                                        scripts. This may be empty if no secret object
-                                        is specified. If the secret object contains
-                                        more than one secret, all secrets are passed
-                                        to the plugin scripts.'
+                                      description: |-
+                                        secretRef is Optional: secretRef is reference to the secret object containing
+                                        sensitive information to pass to the plugin scripts. This may be
+                                        empty if no secret object is specified. If the secret object
+                                        contains more than one secret, all secrets are passed to the plugin
+                                        scripts.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -7333,9 +6796,9 @@ spec:
                                     on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: datasetName is Name of the dataset
-                                        stored as metadata -> name on the dataset
-                                        for Flocker should be considered as deprecated
+                                      description: |-
+                                        datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                        should be considered as deprecated
                                       type: string
                                     datasetUUID:
                                       description: datasetUUID is the UUID of the
@@ -7344,59 +6807,55 @@ spec:
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: 'gcePersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: |-
+                                    gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   properties:
                                     fsType:
-                                      description: 'fsType is filesystem type of the
-                                        volume that you want to mount. Tip: Ensure
-                                        that the filesystem type is supported by the
-                                        host operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: |-
+                                        fsType is filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     partition:
-                                      description: 'partition is the partition in
-                                        the volume that you want to mount. If omitted,
-                                        the default is to mount by volume name. Examples:
-                                        For volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      description: |-
+                                        partition is the partition in the volume that you want to mount.
+                                        If omitted, the default is to mount by volume name.
+                                        Examples: For volume /dev/sda1, you specify the partition as "1".
+                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: 'pdName is unique name of the PD
-                                        resource in GCE. Used to identify the disk
-                                        in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      description: |-
+                                        pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'gitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
+                                  description: |-
+                                    gitRepo represents a git repository at a particular revision.
+                                    DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                    EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                    into the Pod's container.
                                   properties:
                                     directory:
-                                      description: directory is the target directory
-                                        name. Must not contain or start with '..'.  If
-                                        '.' is supplied, the volume directory will
-                                        be the git repository.  Otherwise, if specified,
-                                        the volume will contain the git repository
-                                        in the subdirectory with the given name.
+                                      description: |-
+                                        directory is the target directory name.
+                                        Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                        git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                        the subdirectory with the given name.
                                       type: string
                                     repository:
                                       description: repository is the URL
@@ -7409,55 +6868,61 @@ spec:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: 'glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                  description: |-
+                                    glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                   properties:
                                     endpoints:
-                                      description: 'endpoints is the endpoint name
-                                        that details Glusterfs topology. More info:
-                                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      description: |-
+                                        endpoints is the endpoint name that details Glusterfs topology.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: string
                                     path:
-                                      description: 'path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      description: |-
+                                        path is the Glusterfs volume path.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                      description: |-
+                                        readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                        Defaults to false.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: 'hostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
+                                  description: |-
+                                    hostPath represents a pre-existing file or directory on the host
+                                    machine that is directly exposed to the container. This is generally
+                                    used for system agents or other privileged things that are allowed
+                                    to see the host machine. Most containers will NOT need this.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                    ---
+                                    TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                    mount host directories as read/write.
                                   properties:
                                     path:
-                                      description: 'path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: |-
+                                        path of the directory on the host.
+                                        If the path is a symlink, it will follow the link to the real path.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                       type: string
                                     type:
-                                      description: 'type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      description: |-
+                                        type for HostPath Volume
+                                        Defaults to ""
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: 'iscsi represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                  description: |-
+                                    iscsi represents an ISCSI Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    More info: https://examples.k8s.io/volumes/iscsi/README.md
                                   properties:
                                     chapAuthDiscovery:
                                       description: chapAuthDiscovery defines whether
@@ -7468,30 +6933,27 @@ spec:
                                         support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     initiatorName:
-                                      description: initiatorName is the custom iSCSI
-                                        Initiator Name. If initiatorName is specified
-                                        with iscsiInterface simultaneously, new iSCSI
-                                        interface <target portal>:<volume name> will
-                                        be created for the connection.
+                                      description: |-
+                                        initiatorName is the custom iSCSI Initiator Name.
+                                        If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                        <target portal>:<volume name> will be created for the connection.
                                       type: string
                                     iqn:
                                       description: iqn is the target iSCSI Qualified
                                         Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iscsiInterface is the interface
-                                        Name that uses an iSCSI transport. Defaults
-                                        to 'default' (tcp).
+                                      description: |-
+                                        iscsiInterface is the interface Name that uses an iSCSI transport.
+                                        Defaults to 'default' (tcp).
                                       type: string
                                     lun:
                                       description: lun represents iSCSI Target Lun
@@ -7499,34 +6961,33 @@ spec:
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: portals is the iSCSI Target Portal
-                                        List. The portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
+                                      description: |-
+                                        portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                        is other than default (typically TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
                                       type: boolean
                                     secretRef:
                                       description: secretRef is the CHAP Secret for
                                         iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: targetPortal is iSCSI Target Portal.
-                                        The Portal is either an IP or ip_addr:port
-                                        if the port is other than default (typically
-                                        TCP ports 860 and 3260).
+                                      description: |-
+                                        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                        is other than default (typically TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -7534,44 +6995,51 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'name of the volume. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  description: |-
+                                    name of the volume.
+                                    Must be a DNS_LABEL and unique within the pod.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 nfs:
-                                  description: 'nfs represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: |-
+                                    nfs represents an NFS mount on the host that shares a pod's lifetime
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   properties:
                                     path:
-                                      description: 'path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      description: |-
+                                        path that is exported by the NFS server.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      description: |-
+                                        readOnly here will force the NFS export to be mounted with read-only permissions.
+                                        Defaults to false.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: boolean
                                     server:
-                                      description: 'server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      description: |-
+                                        server is the hostname or IP address of the NFS server.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: 'persistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: |-
+                                    persistentVolumeClaimVolumeSource represents a reference to a
+                                    PersistentVolumeClaim in the same namespace.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   properties:
                                     claimName:
-                                      description: 'claimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: |-
+                                        claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                       type: string
                                     readOnly:
-                                      description: readOnly Will force the ReadOnly
-                                        setting in VolumeMounts. Default false.
+                                      description: |-
+                                        readOnly Will force the ReadOnly setting in VolumeMounts.
+                                        Default false.
                                       type: boolean
                                   required:
                                   - claimName
@@ -7582,11 +7050,10 @@ spec:
                                     host machine
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     pdID:
                                       description: pdID is the ID that identifies
@@ -7600,16 +7067,15 @@ spec:
                                     volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
+                                      description: |-
+                                        fSType represents the filesystem type to mount
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     volumeID:
                                       description: volumeID uniquely identifies a
@@ -7623,16 +7089,13 @@ spec:
                                     secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: defaultMode are the mode bits used
-                                        to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777
-                                        or a decimal value between 0 and 511. YAML
-                                        accepts both octal and decimal values, JSON
-                                        requires decimal values for mode bits. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.
+                                      description: |-
+                                        defaultMode are the mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
@@ -7646,21 +7109,14 @@ spec:
                                               the configMap data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced ConfigMap
-                                                  will be projected into the volume
-                                                  as a file whose name is the key
-                                                  and content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
+                                                description: |-
+                                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                                  ConfigMap will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the ConfigMap,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
                                                 items:
                                                   description: Maps a string key to
                                                     a path within a volume.
@@ -7670,30 +7126,21 @@ spec:
                                                         to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -7701,10 +7148,10 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: optional specify whether
@@ -7747,21 +7194,13 @@ spec:
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: 'Optional: mode
-                                                        bits used to set permissions
-                                                        on this file, must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
+                                                      description: |-
+                                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
@@ -7775,12 +7214,9 @@ spec:
                                                         start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                       properties:
                                                         containerName:
                                                           description: 'Container
@@ -7815,21 +7251,14 @@ spec:
                                               the secret data to project
                                             properties:
                                               items:
-                                                description: items if unspecified,
-                                                  each key-value pair in the Data
-                                                  field of the referenced Secret will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
+                                                description: |-
+                                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                                  Secret will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the Secret,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
                                                 items:
                                                   description: Maps a string key to
                                                     a path within a volume.
@@ -7839,30 +7268,21 @@ spec:
                                                         to project.
                                                       type: string
                                                     mode:
-                                                      description: 'mode is Optional:
-                                                        mode bits used to set permissions
-                                                        on this file. Must be an octal
-                                                        value between 0000 and 0777
-                                                        or a decimal value between
-                                                        0 and 511. YAML accepts both
-                                                        octal and decimal values,
-                                                        JSON requires decimal values
-                                                        for mode bits. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: path is the relative
-                                                        path of the file to map the
-                                                        key to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -7870,10 +7290,10 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: optional field specify
@@ -7888,34 +7308,26 @@ spec:
                                               project
                                             properties:
                                               audience:
-                                                description: audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
+                                                description: |-
+                                                  audience is the intended audience of the token. A recipient of a token
+                                                  must identify itself with an identifier specified in the audience of the
+                                                  token, and otherwise should reject the token. The audience defaults to the
+                                                  identifier of the apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: expirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
+                                                description: |-
+                                                  expirationSeconds is the requested duration of validity of the service
+                                                  account token. As the token approaches expiration, the kubelet volume
+                                                  plugin will proactively rotate the service account token. The kubelet will
+                                                  start trying to rotate the token if the token is older than 80 percent of
+                                                  its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                                   and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
+                                                description: |-
+                                                  path is the path relative to the mount point of the file to project the
+                                                  token into.
                                                 type: string
                                             required:
                                             - path
@@ -7928,30 +7340,30 @@ spec:
                                     on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: group to map volume access to Default
-                                        is no group
+                                      description: |-
+                                        group to map volume access to
+                                        Default is no group
                                       type: string
                                     readOnly:
-                                      description: readOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
+                                      description: |-
+                                        readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                         Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
+                                      description: |-
+                                        registry represents a single or multiple Quobyte Registry services
+                                        specified as a string as host:port pair (multiple entries are separated with commas)
+                                        which acts as the central registry for volumes
                                       type: string
                                     tenant:
-                                      description: tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
+                                      description: |-
+                                        tenant owning the given Quobyte volume in the Backend
+                                        Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                       type: string
                                     user:
-                                      description: user to map volume access to Defaults
-                                        to serivceaccount user
+                                      description: |-
+                                        user to map volume access to
+                                        Defaults to serivceaccount user
                                       type: string
                                     volume:
                                       description: volume is a string that references
@@ -7962,60 +7374,68 @@ spec:
                                   - volume
                                   type: object
                                 rbd:
-                                  description: 'rbd represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                  description: |-
+                                    rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md
                                   properties:
                                     fsType:
-                                      description: 'fsType is the filesystem type
-                                        of the volume that you want to mount. Tip:
-                                        Ensure that the filesystem type is supported
-                                        by the host operating system. Examples: "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     image:
-                                      description: 'image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: |-
+                                        image is the rados image name.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     keyring:
-                                      description: 'keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: |-
+                                        keyring is the path to key ring for RBDUser.
+                                        Default is /etc/ceph/keyring.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     monitors:
-                                      description: 'monitors is a collection of Ceph
-                                        monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: |-
+                                        monitors is a collection of Ceph monitors.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'pool is the rados pool name. Default
-                                        is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: |-
+                                        pool is the rados pool name.
+                                        Default is rbd.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     readOnly:
-                                      description: 'readOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: boolean
                                     secretRef:
-                                      description: 'secretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: |-
+                                        secretRef is name of the authentication secret for RBDUser. If provided
+                                        overrides keyring.
+                                        Default is nil.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: 'user is the rados user name. Default
-                                        is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: |-
+                                        user is the rados user name.
+                                        Default is admin.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                   required:
                                   - image
@@ -8026,10 +7446,11 @@ spec:
                                     volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Default is "xfs".
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs".
+                                        Default is "xfs".
                                       type: string
                                     gateway:
                                       description: gateway is the host address of
@@ -8041,21 +7462,20 @@ spec:
                                         storage.
                                       type: string
                                     readOnly:
-                                      description: readOnly Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
+                                      description: |-
+                                        readOnly Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
+                                      description: |-
+                                        secretRef references to the secret for ScaleIO user and other
+                                        sensitive information. If this is not provided, Login operation will fail.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -8064,9 +7484,9 @@ spec:
                                         SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: storageMode indicates whether the
-                                        storage for a volume should be ThickProvisioned
-                                        or ThinProvisioned. Default is ThinProvisioned.
+                                      description: |-
+                                        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                        Default is ThinProvisioned.
                                       type: string
                                     storagePool:
                                       description: storagePool is the ScaleIO Storage
@@ -8077,9 +7497,9 @@ spec:
                                         system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the name of a volume
-                                        already created in the ScaleIO system that
-                                        is associated with this volume source.
+                                      description: |-
+                                        volumeName is the name of a volume already created in the ScaleIO system
+                                        that is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -8087,35 +7507,30 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: |-
+                                    secret represents a secret that should populate this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   properties:
                                     defaultMode:
-                                      description: 'defaultMode is Optional: mode
-                                        bits used to set permissions on created files
-                                        by default. Must be an octal value between
-                                        0000 and 0777 or a decimal value between 0
-                                        and 511. YAML accepts both octal and decimal
-                                        values, JSON requires decimal values for mode
-                                        bits. Defaults to 0644. Directories within
-                                        the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
+                                      description: |-
+                                        defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values
+                                        for mode bits. Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: items If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
+                                      description: |-
+                                        items If unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -8124,26 +7539,21 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                              used to set permissions on this file.
-                                              Must be an octal value between 0000
-                                              and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. If not specified,
-                                              the volume defaultMode will be used.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path
-                                              of the file to map the key to. May not
-                                              be an absolute path. May not contain
-                                              the path element '..'. May not start
-                                              with the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -8155,9 +7565,9 @@ spec:
                                         the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'secretName is the name of the
-                                        secret in the pod''s namespace to use. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: |-
+                                        secretName is the name of the secret in the pod's namespace to use.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                       type: string
                                   type: object
                                 storageos:
@@ -8165,46 +7575,42 @@ spec:
                                     attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: fsType is the filesystem type to
-                                        mount. Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                        if unspecified.
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     readOnly:
-                                      description: readOnly defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
+                                      description: |-
+                                        secretRef specifies the secret to use for obtaining the StorageOS API
+                                        credentials.  If not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: volumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
+                                      description: |-
+                                        volumeName is the human-readable name of the StorageOS volume.  Volume
+                                        names are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: volumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
+                                      description: |-
+                                        volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                        namespace is specified then the Pod's namespace will be used.  This allows the
+                                        Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                        Set VolumeName to any name to override the default behaviour.
+                                        Set to "default" if you are not using namespaces within StorageOS.
+                                        Namespaces that do not pre-exist within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
@@ -8212,11 +7618,10 @@ spec:
                                     volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the
-                                        host operating system. Ex. "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
+                                      description: |-
+                                        fsType is filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     storagePolicyID:
                                       description: storagePolicyID is the storage
@@ -8243,14 +7648,14 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: ttlSecondsAfterFinished limits the lifetime of a
-                      Job that has finished execution (either Complete or Failed).
-                      If this field is set, ttlSecondsAfterFinished after the Job
-                      finishes, it is eligible to be automatically deleted. When the
-                      Job is being deleted, its lifecycle guarantees (e.g. finalizers)
-                      will be honored. If this field is unset, the Job won't be automatically
-                      deleted. If this field is set to zero, the Job becomes eligible
-                      to be deleted immediately after it finishes.
+                    description: |-
+                      ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                      execution (either Complete or Failed). If this field is set,
+                      ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                      automatically deleted. When the Job is being deleted, its lifecycle
+                      guarantees (e.g. finalizers) will be honored. If this field is unset,
+                      the Job won't be automatically deleted. If this field is set to zero,
+                      the Job becomes eligible to be deleted immediately after it finishes.
                     format: int32
                     type: integer
                 required:


### PR DESCRIPTION
New controller-gen 0.14 has been released. This PR contains the new generated crds.yaml.

Changes in controller-gen v0.14:
- controller-gen.kubebuilder.io/version annotation is bumped in the crds.yaml 
- Multiline added https://github.com/kubernetes-sigs/controller-tools/pull/870 