### PR TITLE
Update BCI base image and Go circl

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.5.36.5.39
+FROM registry.suse.com/bci/bci-base:15.5
 RUN zypper -n update && \
     zypper -n install openssh catatonit && \
     zypper -n clean -a


### PR DESCRIPTION
1. Use `major:minor` version for base image`registry.suse.com/bci/bci-base:15.5` instead of `registry.suse.com/bci/bci-base:15.5.36.5.68`, which is already a month old.

~2. Patch bump of `github.com/cloudflare/circl` to `v1.3.7` to fix advisory GHSA-9763-4f94-gfch.~ → relevant against `master`, but this PR now targets `release/fleet/v0.9` (see [comment](https://github.com/rancher/gitjob/pull/421#issuecomment-1916643083) below), where this has already been applied. 