### PR TITLE
Use `git-core` base pkg instead of `git`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/bci-base:15.5.36.5.39
 RUN zypper -n update && \
-    zypper -n install openssh catatonit && \
+    zypper -n install openssh catatonit git-core && \
     zypper -n clean -a
 RUN useradd -u 1000 -U -m gitjob
 COPY bin/gitjob /usr/bin/


### PR DESCRIPTION
Use the base level package `git-core` that has less dependencies than `git`, reducing image size and possibly future CVEs ("less packages normally means less CVEs").

**git**

```shell
/ # zypper in git
Refreshing service 'container-suseconnect-zypp'.
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 12 NEW packages are going to be installed:
  file git git-core less libexpat1 libgdbm4 libpcre2-8-0 libsha1detectcoll1 perl perl-Error perl-Git which

The following 12 packages are not supported by their vendor:
  file git git-core less libexpat1 libgdbm4 libpcre2-8-0 libsha1detectcoll1 perl perl-Error perl-Git which

12 new packages to install.
Overall download size: 12.5 MiB. Already cached: 0 B. After the operation, additional 69.5 MiB will be used.
```

**git-core**

```shell
/ # zypper in git-core
Refreshing service 'container-suseconnect-zypp'.
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 7 NEW packages are going to be installed:
  file git-core less libexpat1 libpcre2-8-0 libsha1detectcoll1 which

The following 7 packages are not supported by their vendor:
  file git-core less libexpat1 libpcre2-8-0 libsha1detectcoll1 which

7 new packages to install.
Overall download size: 5.6 MiB. Already cached: 0 B. After the operation, additional 28.5 MiB will be used.
```

Note (@weyfonk): This PR initially targeted `master`, hence _replaced_ `git` with `git-core`. But it now targets `release/fleet/v0.9`, where `git` is not in `package/Dockerfile`, although it should be.
This PR now effectively acts as a backport of #362 as well.